### PR TITLE
Add VirtualCam LSPosed module

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,136 @@
-# testvcam
-test
+# VirtualCam LSPosed Module
+
+VirtualCam is an LSPosed module that replaces camera frames with user-selected media. The project is written entirely in Kotlin, uses Jetpack Compose Material 3 for its UI, and provides hooks for legacy `android.hardware.Camera`, Camera2, and CameraX pipelines. The module installs without additional configuration and stores its settings in device protected storage so that hooked processes can access the preferences before user unlock.
+
+## Features
+
+* Compose Material 3 GUI with previews for still images and video sources.
+* Device protected, world-readable preferences plus a Room-backed recent history list.
+* SAF proxy content provider to re-expose the selected media URI to hooked clients.
+* Media pipeline with EXIF-aware orientation handling, bitmap scaling, and YUV/JPEG converters.
+* Legacy camera hooks replacing preview callbacks and still captures.
+* Camera2 preview surface swap with dummy surfaces and canvas painters.
+* CameraX analyzer, image capture, and surface request interception.
+* Diagnostics screen showing pipeline status and the last 20 log lines.
+
+## Architecture
+
+```
+App UI (Compose)
+ ├─ MainActivity – settings + SAF preview
+ ├─ HistoryActivity – Room backed recent list
+ ├─ DiagnosticsActivity – live metrics/logs
+ └─ AboutActivity – version and disclaimer
+
+Storage
+ ├─ ModulePrefs (Device Protected Storage + MODE_WORLD_READABLE)
+ ├─ VirtualCamProvider (SAF proxy)
+ └─ Room database (Recent items)
+
+Hooks
+ ├─ HookEntry – installs once per target process
+ ├─ FakeFrameInjector – bitmap/video scheduler + converters
+ ├─ VideoDecoder – MediaMetadataRetriever/MediaCodec frames
+ ├─ CameraXHooks – Analyzer/ImageCapture/SurfaceRequest
+ └─ GlSurfacePusher – preview painter abstraction
+
+Pipeline
+ Source (SAF) → ExifUtil → BitmapTransform → BitmapConverters
+   → FakeFrameInjector → {NV21 | YUV420 | JPEG} → Hooked API
+```
+
+## Media Flow
+
+```
+[User Media] --(SAF)--> [ModulePrefs]
+                      \-> [VirtualCamProvider]
+[HookEntry] -> [FakeFrameInjector]
+   ├─ loadBitmap()/VideoDecoder
+   ├─ scaleBitmap()/applyOrientationAndMirror
+   ├─ bitmapToNV21 / writeBitmapIntoYUV420 / bitmapToJpeg
+   └─ DiagnosticsState (active path + fps)
+```
+
+## GREP Markers
+
+Key implementation sections are annotated with `// GREP:` comments so that automation scripts can quickly locate the relevant code:
+
+| Marker | File | Purpose |
+|--------|------|---------|
+| `UI_MAIN` | `ui/MainActivity.kt` | Compose control panel |
+| `UI_HISTORY` | `ui/HistoryActivity.kt` | Room backed history list |
+| `UI_DIAG` | `ui/DiagnosticsActivity.kt` | Diagnostics metrics/logs |
+| `UI_ABOUT` | `ui/AboutActivity.kt` | Version info + disclaimer |
+| `PREFS_DPS_WORLD_READABLE` | `prefs/ModulePrefs.kt` | Device protected preferences |
+| `PROVIDER_SAF_PROXY` | `provider/VirtualCamProvider.kt` | SAF proxy provider |
+| `ROOM_*` | `data` package | Room entity/DAO/database |
+| `EXIF_ORIENTATION` | `util/ExifUtil.kt` | Orientation helper |
+| `BITMAP_TRANSFORM` / `YUV_CONVERTERS_IMPL` | `util/BitmapConverters.kt` | Bitmap scaling and YUV/JPEG conversion |
+| `SURFACE_*` | `util/SizeUtil.kt` | Surface detection and painter |
+| `INJECT_PREVIEW_AND_FRAMES` | `xposed/FakeFrameInjector.kt` | Hook core |
+| `DECODER_CODEC_OR_MMR` | `xposed/VideoDecoder.kt` | Media decoding |
+| `HOOK_CAMERAX` | `xposed/CameraXHooks.kt` | CameraX interception |
+| `PREVIEW_CANVAS_OR_EGL` | `xposed/GlSurfacePusher.kt` | Preview painter |
+| `HOOK_ENTRY` | `xposed/HookEntry.kt` | LSPosed entry point |
+
+## Build & Verification
+
+The project ships with the Gradle wrapper scripts (delegating to the environment Gradle ≥8.7). Build and lint the module with:
+
+```bash
+./gradlew clean assembleDebug lint ktlintCheck
+./gradlew test
+```
+
+Install to a connected device:
+
+```bash
+adb install -r app/build/outputs/apk/debug/app-debug.apk
+```
+
+Enable the module from LSPosed Manager, scope it to camera/RTC packages, and read logs using:
+
+```bash
+adb logcat | grep -i VirtualCam
+```
+
+## Runtime Usage
+
+1. Launch VirtualCam and choose Photo or Video.
+2. Pick a file via SAF; the module persists URI permissions.
+3. Adjust scaling, FPS, format, API priority, and injection flags.
+4. Save to persist settings and update the recent history list.
+5. Enable the module in LSPosed, reboot target apps, and observe substituted frames.
+
+## Diagnostics
+
+`DiagnosticsActivity` renders `DiagnosticsState` snapshots showing:
+
+* Active path (Legacy / Camera2 / CameraX / Static / Video).
+* Negotiated preview size & format.
+* Requested vs. measured FPS.
+* The last 20 log messages buffered by `VirtualCamLogBuffer`.
+
+## Troubleshooting
+
+| Signature | Root Cause | Fix |
+|-----------|------------|-----|
+| `// GREP: AMBIGUITY_FIND_METHOD_EXACT` | Attempted to hook parameterless methods with `findMethodExact` causing overload ambiguity. | Use Java reflection (`getMethod()/getConstructor()`) as shown in Camera2 hooks. |
+| `// GREP: AAPT_IC_LAUNCHER_MISSING` | Missing launcher mipmap resources during build. | Ensure adaptive icon XML/vector assets exist (`mipmap-anydpi-v26/ic_launcher.xml`). |
+| `// GREP: JVM_TARGET_MISMATCH` | Kotlin and Java toolchain targets differ. | Both Gradle `compileOptions` and `kotlinOptions.jvmTarget` set to 17; the toolchain is configured to Java 17. |
+| `// GREP: CAMERA2_SESSION_REJECTED` | Camera2 session fails when non-preview surfaces are replaced. | `FakeFrameInjector` guards replacements with `isPreviewSurface` and skips ImageReader outputs. |
+
+## README_DISCLAIMER
+
+This module is intended **only for testing and QA on your own devices**. Respect local laws, app policies, and user privacy. Do **not** deploy VirtualCam to defeat biometrics, anti-fraud, or DRM systems.
+
+## Ideas for Improvement
+
+* Auto-select the closest supported preview size by querying device characteristics and matching to source aspect ratio.
+* Implement a ring buffer of generated frames to reduce allocations during high-FPS playback.
+* Add lightweight profiling to track bitmap conversions and identify hot spots for further optimization.
+
+## Suggested Refactor
+
+Introduce a dedicated `PreviewInjector` interface with Canvas and GL/EGL implementations. Hooks would depend on the abstraction rather than directly calling `startSurfacePainter`, making it easier to swap rendering strategies per API or device.
+

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -1,0 +1,118 @@
+// GREP: GRADLE_APP
+plugins {
+    id("com.android.application")
+    id("org.jetbrains.kotlin.android")
+    id("org.jetbrains.kotlin.kapt")
+    id("org.jlleitschuh.gradle.ktlint")
+}
+
+android {
+    namespace = "com.example.virtualcam"
+    compileSdk = 34
+
+    defaultConfig {
+        applicationId = "com.example.virtualcam"
+        minSdk = 24
+        targetSdk = 34
+        versionCode = 1
+        versionName = "1.0"
+
+        testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
+        vectorDrawables.useSupportLibrary = true
+    }
+
+    buildTypes {
+        getByName("debug") {
+            isMinifyEnabled = false
+        }
+        getByName("release") {
+            isMinifyEnabled = true
+            proguardFiles(
+                getDefaultProguardFile("proguard-android-optimize.txt"),
+                "proguard-rules.pro"
+            )
+        }
+    }
+
+    compileOptions {
+        sourceCompatibility = JavaVersion.VERSION_17
+        targetCompatibility = JavaVersion.VERSION_17
+    }
+
+    kotlinOptions {
+        jvmTarget = "17"
+    }
+
+    buildFeatures {
+        compose = true
+    }
+
+    composeOptions {
+        kotlinCompilerExtensionVersion = "1.5.11"
+    }
+
+    packaging {
+        resources {
+            excludes += 
+                setOf("META-INF/DEPENDENCIES", "META-INF/LICENSE", "META-INF/LICENSE.txt", "META-INF/NOTICE", "META-INF/NOTICE.txt")
+        }
+    }
+
+    lint {
+        checkReleaseBuilds = true
+        abortOnError = true
+    }
+
+    sourceSets.all {
+        java.srcDir("src/main/kotlin")
+    }
+
+    testOptions {
+        unitTests.isIncludeAndroidResources = true
+    }
+}
+
+java {
+    toolchain {
+        languageVersion.set(JavaLanguageVersion.of(17))
+    }
+}
+
+ktlint {
+    android.set(true)
+}
+
+dependencies {
+    implementation(platform("androidx.compose:compose-bom:2024.06.00"))
+    implementation("androidx.compose.ui:ui")
+    implementation("androidx.compose.foundation:foundation")
+    implementation("androidx.compose.material3:material3")
+    implementation("androidx.compose.material:material-icons-extended")
+    implementation("androidx.compose.ui:ui-tooling-preview")
+    debugImplementation("androidx.compose.ui:ui-tooling")
+    debugImplementation("androidx.compose.ui:ui-test-manifest")
+
+    implementation("androidx.activity:activity-compose:1.9.3")
+    implementation("androidx.lifecycle:lifecycle-runtime-ktx:2.8.4")
+    implementation("androidx.lifecycle:lifecycle-runtime-compose:2.8.4")
+    implementation("androidx.core:core-ktx:1.13.1")
+    implementation("androidx.exifinterface:exifinterface:1.3.7")
+    implementation("org.jetbrains.kotlinx:kotlinx-coroutines-android:1.8.1")
+
+    implementation("io.coil-kt:coil-compose:2.6.0")
+
+    implementation("androidx.room:room-runtime:2.6.1")
+    implementation("androidx.room:room-ktx:2.6.1")
+    kapt("androidx.room:room-compiler:2.6.1")
+
+    compileOnly("de.robv.android.xposed:api:82")
+    compileOnly("androidx.camera:camera-core:1.3.4")
+    compileOnly("androidx.camera:camera-camera2:1.3.4")
+    compileOnly("androidx.camera:camera-lifecycle:1.3.4")
+
+    testImplementation("junit:junit:4.13.2")
+    androidTestImplementation("androidx.test.ext:junit:1.1.5")
+    androidTestImplementation("androidx.test.espresso:espresso-core:3.5.1")
+    androidTestImplementation(platform("androidx.compose:compose-bom:2024.06.00"))
+    androidTestImplementation("androidx.compose.ui:ui-test-junit4")
+}

--- a/app/proguard-rules.pro
+++ b/app/proguard-rules.pro
@@ -1,0 +1,18 @@
+# GREP: PROGUARD_VIRTUALCAM
+-keep class de.robv.android.xposed.** { *; }
+-dontwarn de.robv.android.xposed.**
+-keep class com.example.virtualcam.xposed.** { *; }
+
+-keepclassmembers class android.hardware.camera2.params.SessionConfiguration {
+    public *** getOutputConfigurations(...);
+    public *** getSessionType(...);
+    public *** getExecutor(...);
+    public *** getStateCallback(...);
+}
+-keepclassmembers class android.hardware.camera2.params.OutputConfiguration {
+    public <init>(android.view.Surface);
+    public android.view.Surface getSurface(...);
+}
+
+-keep class androidx.room.** { *; }
+-keep class kotlin.Metadata { *; }

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -1,0 +1,57 @@
+<!-- GREP: MANIFEST_VIRTUALCAM -->
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+    package="com.example.virtualcam">
+
+    <application
+        android:name="com.example.virtualcam.VirtualCamApp"
+        android:allowBackup="false"
+        android:dataExtractionRules="@xml/data_extraction_rules"
+        android:fullBackupContent="false"
+        android:icon="@mipmap/ic_launcher"
+        android:label="VirtualCam"
+        android:roundIcon="@mipmap/ic_launcher"
+        android:supportsRtl="true"
+        android:theme="@style/Theme.VirtualCam">
+
+        <activity
+            android:name="com.example.virtualcam.ui.AboutActivity"
+            android:exported="false"
+            android:label="About" />
+        <activity
+            android:name="com.example.virtualcam.ui.DiagnosticsActivity"
+            android:exported="false"
+            android:label="Diagnostics" />
+        <activity
+            android:name="com.example.virtualcam.ui.HistoryActivity"
+            android:exported="false"
+            android:label="History" />
+        <activity
+            android:name="com.example.virtualcam.ui.MainActivity"
+            android:exported="true"
+            android:label="VirtualCam">
+            <intent-filter>
+                <action android:name="android.intent.action.MAIN" />
+                <category android:name="android.intent.category.LAUNCHER" />
+            </intent-filter>
+        </activity>
+
+        <provider
+            android:name="com.example.virtualcam.provider.VirtualCamProvider"
+            android:authorities="com.example.virtualcam.provider"
+            android:enabled="true"
+            android:exported="true"
+            android:grantUriPermissions="true"
+            android:readPermission="android.permission.READ_EXTERNAL_STORAGE"
+            android:writePermission="android.permission.READ_EXTERNAL_STORAGE" />
+
+        <meta-data
+            android:name="xposedmodule"
+            android:value="true" />
+        <meta-data
+            android:name="xposeddescription"
+            android:value="Virtual camera stream substitution" />
+        <meta-data
+            android:name="xposedminversion"
+            android:value="93" />
+    </application>
+</manifest>

--- a/app/src/main/assets/xposed_init
+++ b/app/src/main/assets/xposed_init
@@ -1,0 +1,1 @@
+com.example.virtualcam.xposed.HookEntry

--- a/app/src/main/java/com/example/virtualcam/VirtualCamApp.kt
+++ b/app/src/main/java/com/example/virtualcam/VirtualCamApp.kt
@@ -1,0 +1,70 @@
+package com.example.virtualcam
+
+import android.app.Application
+import android.util.Log
+import com.example.virtualcam.data.AppDatabase
+import com.example.virtualcam.prefs.ModulePrefs
+import java.util.concurrent.CopyOnWriteArrayList
+
+// GREP: VCAM_TAG
+const val VCAM_TAG = "VirtualCam"
+
+// GREP: VCAM_LOGGER
+fun logVcam(msg: String) {
+    Log.i(VCAM_TAG, msg)
+    VirtualCamLogBuffer.append(msg)
+}
+
+object VirtualCamLogBuffer {
+    private const val MAX_LINES = 200
+    private val buffer = ArrayDeque<String>()
+    private val listeners = CopyOnWriteArrayList<(List<String>) -> Unit>()
+
+    fun append(line: String) {
+        synchronized(buffer) {
+            buffer.addLast(line)
+            while (buffer.size > MAX_LINES) {
+                buffer.removeFirst()
+            }
+            val snapshot = buffer.toList()
+            listeners.forEach { it.invoke(snapshot) }
+        }
+    }
+
+    fun snapshot(): List<String> = synchronized(buffer) { buffer.toList() }
+
+    fun register(listener: (List<String>) -> Unit) {
+        listeners += listener
+        listener(snapshot())
+    }
+
+    fun unregister(listener: (List<String>) -> Unit) {
+        listeners -= listener
+    }
+}
+
+class VirtualCamApp : Application() {
+
+    lateinit var database: AppDatabase
+        private set
+
+    lateinit var modulePrefs: ModulePrefs
+        private set
+
+    override fun onCreate() {
+        super.onCreate()
+        instance = this
+        database = AppDatabase.get(this)
+        modulePrefs = ModulePrefs.getInstance(this)
+        logVcam("VirtualCamApp initialized")
+    }
+
+    companion object {
+        @Volatile
+        private var instance: VirtualCamApp? = null
+
+        fun get(): VirtualCamApp {
+            return instance ?: throw IllegalStateException("VirtualCamApp not yet created")
+        }
+    }
+}

--- a/app/src/main/java/com/example/virtualcam/data/AppDatabase.kt
+++ b/app/src/main/java/com/example/virtualcam/data/AppDatabase.kt
@@ -1,0 +1,30 @@
+package com.example.virtualcam.data
+
+import android.content.Context
+import androidx.room.Database
+import androidx.room.Room
+import androidx.room.RoomDatabase
+import com.example.virtualcam.data.dao.RecentDao
+import com.example.virtualcam.data.entity.RecentItem
+
+// GREP: ROOM_DB
+@Database(entities = [RecentItem::class], version = 1, exportSchema = false)
+abstract class AppDatabase : RoomDatabase() {
+
+    abstract fun recentDao(): RecentDao
+
+    companion object {
+        @Volatile
+        private var INSTANCE: AppDatabase? = null
+
+        fun get(context: Context): AppDatabase {
+            return INSTANCE ?: synchronized(this) {
+                INSTANCE ?: Room.databaseBuilder(
+                    context.applicationContext,
+                    AppDatabase::class.java,
+                    "virtualcam.db"
+                ).fallbackToDestructiveMigration().build().also { INSTANCE = it }
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/example/virtualcam/data/dao/RecentDao.kt
+++ b/app/src/main/java/com/example/virtualcam/data/dao/RecentDao.kt
@@ -1,0 +1,21 @@
+package com.example.virtualcam.data.dao
+
+import androidx.room.Dao
+import androidx.room.Insert
+import androidx.room.OnConflictStrategy
+import androidx.room.Query
+import com.example.virtualcam.data.entity.RecentItem
+import kotlinx.coroutines.flow.Flow
+
+// GREP: ROOM_DAO_RECENT
+@Dao
+interface RecentDao {
+    @Query("SELECT * FROM recent_items ORDER BY addedAt DESC")
+    fun observeAll(): Flow<List<RecentItem>>
+
+    @Insert(onConflict = OnConflictStrategy.REPLACE)
+    suspend fun insert(item: RecentItem)
+
+    @Query("DELETE FROM recent_items")
+    suspend fun clear()
+}

--- a/app/src/main/java/com/example/virtualcam/data/entity/RecentItem.kt
+++ b/app/src/main/java/com/example/virtualcam/data/entity/RecentItem.kt
@@ -1,0 +1,13 @@
+package com.example.virtualcam.data.entity
+
+import androidx.room.Entity
+import androidx.room.PrimaryKey
+
+// GREP: ROOM_ENTITY_RECENT
+@Entity(tableName = "recent_items")
+data class RecentItem(
+    @PrimaryKey(autoGenerate = true) val id: Long = 0,
+    val uri: String,
+    val type: String,
+    val addedAt: Long
+)

--- a/app/src/main/java/com/example/virtualcam/prefs/ModulePrefs.kt
+++ b/app/src/main/java/com/example/virtualcam/prefs/ModulePrefs.kt
@@ -1,0 +1,182 @@
+package com.example.virtualcam.prefs
+
+import android.content.Context
+import android.content.SharedPreferences
+import android.net.Uri
+import android.os.Build
+import androidx.core.content.edit
+import com.example.virtualcam.logVcam
+import java.io.File
+
+// GREP: PREF_KEYS
+object PrefKeys {
+    const val PREF_FILE = "virtualcam_prefs"
+    const val ENABLED = "enabled"
+    const val SOURCE_TYPE = "source_type"
+    const val SOURCE_URI = "source_uri"
+    const val SCALE_MODE = "scale_mode"
+    const val MANUAL_W = "manual_w"
+    const val MANUAL_H = "manual_h"
+    const val FPS = "fps"
+    const val ORIENTATION = "orientation"
+    const val MIRROR = "mirror"
+    const val FORMAT = "format"
+    const val API_PRIORITY = "api_priority"
+    const val VIDEO_MODE = "video_mode"
+    const val INJECT_CAM2_PREVIEW = "inject_cam2_preview"
+    const val VERBOSE = "verbose"
+}
+
+enum class SourceType(val storageValue: String) {
+    IMAGE("image"),
+    VIDEO("video");
+
+    companion object {
+        fun fromStorage(value: String?): SourceType = values().firstOrNull { it.storageValue == value } ?: IMAGE
+    }
+}
+
+enum class ScaleMode(val storageValue: String) {
+    FIT("FIT"),
+    CENTER_CROP("CENTER_CROP");
+
+    companion object {
+        fun fromStorage(value: String?): ScaleMode = values().firstOrNull { it.storageValue == value } ?: FIT
+    }
+}
+
+enum class OrientationOption(val storageValue: String, val degrees: Int?) {
+    AUTO("auto", null),
+    DEG_90("90", 90),
+    DEG_180("180", 180),
+    DEG_270("270", 270);
+
+    companion object {
+        fun fromStorage(value: String?): OrientationOption = values().firstOrNull { it.storageValue == value } ?: AUTO
+    }
+}
+
+enum class FrameFormat(val storageValue: String) {
+    NV21("NV21"),
+    YUV_420_888("YUV_420_888"),
+    JPEG("JPEG");
+
+    companion object {
+        fun fromStorage(value: String?): FrameFormat = values().firstOrNull { it.storageValue == value } ?: NV21
+    }
+}
+
+enum class ApiPriority(val storageValue: String) {
+    AUTO("Auto"),
+    LEGACY("Legacy"),
+    CAMERA2("Camera2"),
+    CAMERAX("CameraX");
+
+    companion object {
+        fun fromStorage(value: String?): ApiPriority = values().firstOrNull { it.storageValue == value } ?: AUTO
+    }
+}
+
+enum class VideoMode(val storageValue: String) {
+    MMR("MMR"),
+    CODEC("Codec");
+
+    companion object {
+        fun fromStorage(value: String?): VideoMode = values().firstOrNull { it.storageValue == value } ?: MMR
+    }
+}
+
+data class ModuleSettings(
+    val enabled: Boolean = false,
+    val sourceType: SourceType = SourceType.IMAGE,
+    val sourceUri: Uri? = null,
+    val scaleMode: ScaleMode = ScaleMode.FIT,
+    val manualWidth: Int? = null,
+    val manualHeight: Int? = null,
+    val fps: Float = 30f,
+    val orientation: OrientationOption = OrientationOption.AUTO,
+    val mirror: Boolean = false,
+    val format: FrameFormat = FrameFormat.NV21,
+    val apiPriority: ApiPriority = ApiPriority.AUTO,
+    val videoMode: VideoMode = VideoMode.MMR,
+    val injectCam2Preview: Boolean = false,
+    val verbose: Boolean = false
+)
+
+class ModulePrefs private constructor(context: Context) {
+
+    // GREP: PREFS_DPS_WORLD_READABLE
+    private val dpsContext: Context = context.createDeviceProtectedStorageContext()
+    private val prefs: SharedPreferences
+
+    init {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) {
+            dpsContext.moveSharedPreferencesFrom(context, PrefKeys.PREF_FILE)
+        }
+        @Suppress("DEPRECATION")
+        val mode = Context.MODE_WORLD_READABLE
+        prefs = dpsContext.getSharedPreferences(PrefKeys.PREF_FILE, mode)
+        ensureWorldReadable()
+    }
+
+    private fun ensureWorldReadable() {
+        val file = File(dpsContext.dataDir, "shared_prefs/${PrefKeys.PREF_FILE}.xml")
+        if (file.exists()) {
+            val readable = file.setReadable(true, false)
+            if (!readable) {
+                logVcam("ModulePrefs failed to mark prefs world-readable")
+            }
+        }
+    }
+
+    fun read(): ModuleSettings {
+        val uriString = prefs.getString(PrefKeys.SOURCE_URI, null)
+        return ModuleSettings(
+            enabled = prefs.getBoolean(PrefKeys.ENABLED, false),
+            sourceType = SourceType.fromStorage(prefs.getString(PrefKeys.SOURCE_TYPE, SourceType.IMAGE.storageValue)),
+            sourceUri = uriString?.let { Uri.parse(it) },
+            scaleMode = ScaleMode.fromStorage(prefs.getString(PrefKeys.SCALE_MODE, ScaleMode.FIT.storageValue)),
+            manualWidth = prefs.getInt(PrefKeys.MANUAL_W, 0).let { if (it <= 0) null else it },
+            manualHeight = prefs.getInt(PrefKeys.MANUAL_H, 0).let { if (it <= 0) null else it },
+            fps = prefs.getFloat(PrefKeys.FPS, 30f),
+            orientation = OrientationOption.fromStorage(prefs.getString(PrefKeys.ORIENTATION, OrientationOption.AUTO.storageValue)),
+            mirror = prefs.getBoolean(PrefKeys.MIRROR, false),
+            format = FrameFormat.fromStorage(prefs.getString(PrefKeys.FORMAT, FrameFormat.NV21.storageValue)),
+            apiPriority = ApiPriority.fromStorage(prefs.getString(PrefKeys.API_PRIORITY, ApiPriority.AUTO.storageValue)),
+            videoMode = VideoMode.fromStorage(prefs.getString(PrefKeys.VIDEO_MODE, VideoMode.MMR.storageValue)),
+            injectCam2Preview = prefs.getBoolean(PrefKeys.INJECT_CAM2_PREVIEW, false),
+            verbose = prefs.getBoolean(PrefKeys.VERBOSE, false)
+        )
+    }
+
+    fun write(settings: ModuleSettings) {
+        prefs.edit(commit = true) {
+            putBoolean(PrefKeys.ENABLED, settings.enabled)
+            putString(PrefKeys.SOURCE_TYPE, settings.sourceType.storageValue)
+            putString(PrefKeys.SOURCE_URI, settings.sourceUri?.toString())
+            putString(PrefKeys.SCALE_MODE, settings.scaleMode.storageValue)
+            putInt(PrefKeys.MANUAL_W, settings.manualWidth ?: 0)
+            putInt(PrefKeys.MANUAL_H, settings.manualHeight ?: 0)
+            putFloat(PrefKeys.FPS, settings.fps)
+            putString(PrefKeys.ORIENTATION, settings.orientation.storageValue)
+            putBoolean(PrefKeys.MIRROR, settings.mirror)
+            putString(PrefKeys.FORMAT, settings.format.storageValue)
+            putString(PrefKeys.API_PRIORITY, settings.apiPriority.storageValue)
+            putString(PrefKeys.VIDEO_MODE, settings.videoMode.storageValue)
+            putBoolean(PrefKeys.INJECT_CAM2_PREVIEW, settings.injectCam2Preview)
+            putBoolean(PrefKeys.VERBOSE, settings.verbose)
+        }
+        ensureWorldReadable()
+    }
+
+    companion object {
+        @Volatile
+        private var instance: ModulePrefs? = null
+
+        fun getInstance(context: Context): ModulePrefs {
+            return instance ?: synchronized(this) {
+                instance ?: ModulePrefs(context.applicationContext).also { instance = it }
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/example/virtualcam/provider/VirtualCamProvider.kt
+++ b/app/src/main/java/com/example/virtualcam/provider/VirtualCamProvider.kt
@@ -1,0 +1,62 @@
+package com.example.virtualcam.provider
+
+import android.content.ContentProvider
+import android.content.ContentValues
+import android.database.Cursor
+import android.content.Intent
+import android.net.Uri
+import android.os.ParcelFileDescriptor
+import com.example.virtualcam.logVcam
+import com.example.virtualcam.prefs.ModulePrefs
+import java.io.FileNotFoundException
+
+// GREP: PROVIDER_SAF_PROXY
+class VirtualCamProvider : ContentProvider() {
+
+    override fun onCreate(): Boolean = true
+
+    override fun query(
+        uri: Uri,
+        projection: Array<out String>?,
+        selection: String?,
+        selectionArgs: Array<out String>?,
+        sortOrder: String?
+    ): Cursor? = null
+
+    override fun getType(uri: Uri): String? {
+        val context = context ?: return null
+        val settings = ModulePrefs.getInstance(context).read()
+        val sourceUri = settings.sourceUri ?: return null
+        return context.contentResolver.getType(sourceUri)
+    }
+
+    override fun insert(uri: Uri, values: ContentValues?): Uri? = null
+
+    override fun delete(uri: Uri, selection: String?, selectionArgs: Array<out String>?): Int = 0
+
+    override fun update(
+        uri: Uri,
+        values: ContentValues?,
+        selection: String?,
+        selectionArgs: Array<out String>?
+    ): Int = 0
+
+    override fun openFile(uri: Uri, mode: String): ParcelFileDescriptor? {
+        val context = context ?: throw FileNotFoundException("No context")
+        val settings = ModulePrefs.getInstance(context).read()
+        val sourceUri = settings.sourceUri ?: throw FileNotFoundException("Source not configured")
+        if (uri.path != "/selected") {
+            throw FileNotFoundException("Unsupported path: ${uri.path}")
+        }
+        val callingPkg = callingPackage
+        if (callingPkg != null) {
+            val flags = Intent.FLAG_GRANT_READ_URI_PERMISSION or Intent.FLAG_GRANT_WRITE_URI_PERMISSION
+            try {
+                context.grantUriPermission(callingPkg, sourceUri, flags)
+            } catch (err: SecurityException) {
+                logVcam("grantUriPermission failed: ${err.message}")
+            }
+        }
+        return context.contentResolver.openFileDescriptor(sourceUri, mode)
+    }
+}

--- a/app/src/main/java/com/example/virtualcam/ui/AboutActivity.kt
+++ b/app/src/main/java/com/example/virtualcam/ui/AboutActivity.kt
@@ -1,0 +1,67 @@
+package com.example.virtualcam.ui
+
+import android.content.Intent
+import android.net.Uri
+import android.os.Bundle
+import androidx.activity.ComponentActivity
+import androidx.activity.compose.setContent
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.Button
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.text.AnnotatedString
+import androidx.compose.ui.text.buildAnnotatedString
+import androidx.compose.ui.text.style.TextDecoration
+import androidx.compose.ui.unit.dp
+import com.example.virtualcam.BuildConfig
+import com.example.virtualcam.ui.theme.VirtualCamTheme
+
+// GREP: UI_ABOUT
+class AboutActivity : ComponentActivity() {
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        setContent {
+            VirtualCamTheme {
+                AboutScreen()
+            }
+        }
+    }
+}
+
+@Composable
+private fun AboutScreen() {
+    val context = LocalContext.current
+    val repoLink = "https://github.com/example/virtualcam"
+    Column(
+        modifier = Modifier
+            .fillMaxSize()
+            .padding(16.dp),
+        verticalArrangement = Arrangement.spacedBy(12.dp)
+    ) {
+        Text(text = "VirtualCam", style = MaterialTheme.typography.headlineMedium)
+        Text(text = "Version: ${BuildConfig.VERSION_NAME}")
+        Text(text = "License: Apache-2.0")
+        Text(
+            text = "Репозиторий:",
+            style = MaterialTheme.typography.titleMedium
+        )
+        Button(onClick = {
+            val intent = Intent(Intent.ACTION_VIEW, Uri.parse(repoLink))
+            context.startActivity(intent)
+        }, modifier = Modifier.fillMaxWidth()) {
+            Text(text = repoLink)
+        }
+        Text(text = "DISCLAIMER", style = MaterialTheme.typography.titleMedium)
+        Text(
+            text = "Этот модуль предназначен только для тестирования и QA на ваших устройствах. Соблюдайте законы, правила приложений и приватность. Не используйте для обхода биометрии, анти-фрода и DRM.",
+            style = MaterialTheme.typography.bodyMedium
+        )
+    }
+}

--- a/app/src/main/java/com/example/virtualcam/ui/DiagnosticsActivity.kt
+++ b/app/src/main/java/com/example/virtualcam/ui/DiagnosticsActivity.kt
@@ -1,0 +1,81 @@
+package com.example.virtualcam.ui
+
+import android.os.Bundle
+import androidx.activity.ComponentActivity
+import androidx.activity.compose.setContent
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.material3.Card
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import com.example.virtualcam.VirtualCamLogBuffer
+import com.example.virtualcam.ui.theme.VirtualCamTheme
+import com.example.virtualcam.xposed.DiagnosticsSnapshot
+import com.example.virtualcam.xposed.DiagnosticsState
+import kotlinx.coroutines.flow.collectLatest
+
+// GREP: UI_DIAG
+class DiagnosticsActivity : ComponentActivity() {
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        setContent {
+            VirtualCamTheme {
+                val snapshot by DiagnosticsState.state.collectAsState()
+                var logs by remember { mutableStateOf(VirtualCamLogBuffer.snapshot()) }
+                DisposableEffect(Unit) {
+                    val listener: (List<String>) -> Unit = { lines -> logs = lines }
+                    VirtualCamLogBuffer.register(listener)
+                    onDispose { VirtualCamLogBuffer.unregister(listener) }
+                }
+                DiagnosticsScreen(snapshot = snapshot, logs = logs.takeLast(20).reversed())
+            }
+        }
+    }
+}
+
+@Composable
+private fun DiagnosticsScreen(snapshot: DiagnosticsSnapshot, logs: List<String>) {
+    Column(
+        modifier = Modifier
+            .fillMaxSize()
+            .padding(16.dp),
+        verticalArrangement = Arrangement.spacedBy(12.dp)
+    ) {
+        Text(text = "Диагностика", style = MaterialTheme.typography.headlineMedium)
+        Card(modifier = Modifier.fillMaxWidth()) {
+            Column(modifier = Modifier.padding(12.dp), verticalArrangement = Arrangement.spacedBy(4.dp)) {
+                Text("Active path: ${snapshot.activePath}")
+                Text("Preview size: ${snapshot.previewSize}")
+                Text("Frame format: ${snapshot.frameFormat}")
+                Text("Requested FPS: ${"%.2f".format(snapshot.requestedFps)}")
+                Text("Actual FPS: ${"%.2f".format(snapshot.actualFps)}")
+            }
+        }
+        Text(text = "Последние логи", style = MaterialTheme.typography.titleMedium)
+        LazyColumn(verticalArrangement = Arrangement.spacedBy(4.dp)) {
+            items(logs) { line ->
+                Card(modifier = Modifier.fillMaxWidth()) {
+                    Text(
+                        text = line,
+                        modifier = Modifier.padding(8.dp),
+                        style = MaterialTheme.typography.bodySmall
+                    )
+                }
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/example/virtualcam/ui/HistoryActivity.kt
+++ b/app/src/main/java/com/example/virtualcam/ui/HistoryActivity.kt
@@ -1,0 +1,132 @@
+package com.example.virtualcam.ui
+
+import android.app.Activity
+import android.net.Uri
+import android.os.Bundle
+import android.widget.Toast
+import androidx.activity.ComponentActivity
+import androidx.activity.compose.setContent
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.material3.Button
+import androidx.compose.material3.Card
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import androidx.lifecycle.lifecycleScope
+import coil.compose.AsyncImage
+import com.example.virtualcam.VirtualCamApp
+import com.example.virtualcam.data.entity.RecentItem
+import com.example.virtualcam.prefs.ModulePrefs
+import com.example.virtualcam.prefs.SourceType
+import com.example.virtualcam.ui.theme.VirtualCamTheme
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
+
+// GREP: UI_HISTORY
+class HistoryActivity : ComponentActivity() {
+
+    private val modulePrefs: ModulePrefs by lazy { VirtualCamApp.get().modulePrefs }
+    private val recentDao by lazy { VirtualCamApp.get().database.recentDao() }
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        setContent {
+            VirtualCamTheme {
+                val recentItems by recentDao.observeAll().collectAsState(initial = emptyList())
+                HistoryScreen(
+                    recentItems = recentItems,
+                    onApply = { item -> applyRecent(item) },
+                    onClear = { clearHistory() }
+                )
+            }
+        }
+    }
+
+    private fun applyRecent(item: RecentItem) {
+        val uri = Uri.parse(item.uri)
+        lifecycleScope.launch {
+            withContext(Dispatchers.IO) {
+                val current = modulePrefs.read()
+                modulePrefs.write(
+                    current.copy(
+                        sourceUri = uri,
+                        sourceType = SourceType.fromStorage(item.type)
+                    )
+                )
+            }
+            Toast.makeText(this@HistoryActivity, "Источник применён", Toast.LENGTH_SHORT).show()
+            setResult(Activity.RESULT_OK)
+            finish()
+        }
+    }
+
+    private fun clearHistory() {
+        lifecycleScope.launch {
+            withContext(Dispatchers.IO) { recentDao.clear() }
+            Toast.makeText(this@HistoryActivity, "История очищена", Toast.LENGTH_SHORT).show()
+        }
+    }
+}
+
+@Composable
+private fun HistoryScreen(
+    recentItems: List<RecentItem>,
+    onApply: (RecentItem) -> Unit,
+    onClear: () -> Unit
+) {
+    Column(
+        modifier = Modifier
+            .fillMaxSize()
+            .padding(16.dp),
+        verticalArrangement = Arrangement.spacedBy(12.dp)
+    ) {
+        Text(text = "История", style = MaterialTheme.typography.headlineMedium)
+        Button(onClick = onClear, modifier = Modifier.align(Alignment.End)) {
+            Text("Очистить")
+        }
+        LazyColumn(verticalArrangement = Arrangement.spacedBy(8.dp), modifier = Modifier.weight(1f, fill = true)) {
+            items(recentItems) { item ->
+                HistoryRow(item = item, onApply = onApply)
+            }
+        }
+    }
+}
+
+@Composable
+private fun HistoryRow(item: RecentItem, onApply: (RecentItem) -> Unit) {
+    Card(modifier = Modifier
+        .fillMaxWidth()
+        .clickable { onApply(item) }) {
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(12.dp),
+            horizontalArrangement = Arrangement.spacedBy(12.dp),
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            AsyncImage(
+                model = Uri.parse(item.uri),
+                contentDescription = null,
+                modifier = Modifier.weight(0.3f)
+            )
+            Column(modifier = Modifier.weight(0.7f)) {
+                Text(text = item.type, style = MaterialTheme.typography.labelLarge)
+                Text(text = item.uri, style = MaterialTheme.typography.bodySmall, maxLines = 2)
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/example/virtualcam/ui/MainActivity.kt
+++ b/app/src/main/java/com/example/virtualcam/ui/MainActivity.kt
@@ -1,0 +1,438 @@
+package com.example.virtualcam.ui
+
+import android.content.Intent
+import android.media.MediaMetadataRetriever
+import android.net.Uri
+import android.os.Bundle
+import android.widget.Toast
+import androidx.activity.ComponentActivity
+import androidx.activity.compose.rememberLauncherForActivityResult
+import androidx.activity.result.contract.ActivityResultContracts
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material3.Button
+import androidx.compose.material3.Card
+import androidx.compose.material3.Divider
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.Slider
+import androidx.compose.material3.Switch
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.asImageBitmap
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.unit.dp
+import coil.compose.AsyncImage
+import com.example.virtualcam.R
+import com.example.virtualcam.VirtualCamApp
+import com.example.virtualcam.data.dao.RecentDao
+import com.example.virtualcam.data.entity.RecentItem
+import com.example.virtualcam.prefs.ApiPriority
+import com.example.virtualcam.prefs.FrameFormat
+import com.example.virtualcam.prefs.ModulePrefs
+import com.example.virtualcam.prefs.ModuleSettings
+import com.example.virtualcam.prefs.OrientationOption
+import com.example.virtualcam.prefs.ScaleMode
+import com.example.virtualcam.prefs.SourceType
+import com.example.virtualcam.prefs.VideoMode
+import com.example.virtualcam.ui.theme.VirtualCamTheme
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
+import java.util.concurrent.TimeUnit
+
+// GREP: UI_MAIN
+class MainActivity : ComponentActivity() {
+
+    private val modulePrefs: ModulePrefs by lazy { VirtualCamApp.get().modulePrefs }
+    private val recentDao: RecentDao by lazy { VirtualCamApp.get().database.recentDao() }
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        setContent {
+            VirtualCamTheme {
+                MainScreen(
+                    modulePrefs = modulePrefs,
+                    recentDao = recentDao,
+                    onOpenHistory = { startActivity(Intent(this, HistoryActivity::class.java)) },
+                    onOpenDiagnostics = { startActivity(Intent(this, DiagnosticsActivity::class.java)) },
+                    onOpenAbout = { startActivity(Intent(this, AboutActivity::class.java)) }
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun MainScreen(
+    modulePrefs: ModulePrefs,
+    recentDao: RecentDao,
+    onOpenHistory: () -> Unit,
+    onOpenDiagnostics: () -> Unit,
+    onOpenAbout: () -> Unit
+) {
+    val context = LocalContext.current
+    var settingsState by remember { mutableStateOf(modulePrefs.read()) }
+    var videoSlider by remember { mutableStateOf(0f) }
+    var videoDuration by remember { mutableStateOf(0L) }
+    val coroutineScope = rememberCoroutineScope()
+
+    LaunchedEffect(modulePrefs) {
+        settingsState = modulePrefs.read()
+        videoSlider = 0f
+    }
+
+    val launcher = rememberLauncherForActivityResult(ActivityResultContracts.OpenDocument()) { uri: Uri? ->
+        if (uri != null) {
+            val flags = Intent.FLAG_GRANT_READ_URI_PERMISSION or Intent.FLAG_GRANT_WRITE_URI_PERMISSION
+            try {
+                context.contentResolver.takePersistableUriPermission(uri, flags)
+            } catch (err: SecurityException) {
+                Toast.makeText(context, "Persist permission failed: ${err.message}", Toast.LENGTH_LONG).show()
+            }
+            settingsState = settingsState.copy(sourceUri = uri)
+            if (settingsState.sourceType == SourceType.VIDEO) {
+                videoSlider = 0f
+            }
+        }
+    }
+
+    Column(
+        modifier = Modifier
+            .fillMaxSize()
+            .verticalScroll(rememberScrollState())
+            .padding(16.dp),
+        verticalArrangement = Arrangement.spacedBy(16.dp)
+    ) {
+        Text(text = "VirtualCam Settings", style = MaterialTheme.typography.headlineMedium)
+        SegmentedToggle(
+            options = listOf("Photo", "Video"),
+            selectedIndex = if (settingsState.sourceType == SourceType.IMAGE) 0 else 1
+        ) { index ->
+            val newType = if (index == 0) SourceType.IMAGE else SourceType.VIDEO
+            if (newType != settingsState.sourceType && newType == SourceType.VIDEO) {
+                videoSlider = 0f
+                videoDuration = 0L
+            }
+            settingsState = settingsState.copy(sourceType = newType)
+        }
+        Button(onClick = { launcher.launch(arrayOf("image/*", "video/*")) }) {
+            Text(text = "Выбрать источник")
+        }
+        PreviewCard(
+            settings = settingsState,
+            sliderPosition = videoSlider,
+            onDurationLoaded = { videoDuration = it },
+            onSliderChanged = { videoSlider = it }
+        )
+        Divider()
+        SwitchRow(
+            title = "Enable module",
+            checked = settingsState.enabled,
+            onCheckedChange = { settingsState = settingsState.copy(enabled = it) }
+        )
+        SwitchRow(
+            title = "Mirror output",
+            checked = settingsState.mirror,
+            onCheckedChange = { settingsState = settingsState.copy(mirror = it) }
+        )
+        SwitchRow(
+            title = "Camera2 preview injection",
+            checked = settingsState.injectCam2Preview,
+            onCheckedChange = { settingsState = settingsState.copy(injectCam2Preview = it) }
+        )
+        SwitchRow(
+            title = "Verbose logs",
+            checked = settingsState.verbose,
+            onCheckedChange = { settingsState = settingsState.copy(verbose = it) }
+        )
+        DropdownRow(
+            label = "Scale mode",
+            value = settingsState.scaleMode.storageValue,
+            options = ScaleMode.values().map { it.storageValue },
+        ) { selection ->
+            settingsState = settingsState.copy(scaleMode = ScaleMode.fromStorage(selection))
+        }
+        DropdownRow(
+            label = "Frame format",
+            value = settingsState.format.storageValue,
+            options = FrameFormat.values().map { it.storageValue },
+        ) { selection ->
+            settingsState = settingsState.copy(format = FrameFormat.fromStorage(selection))
+        }
+        DropdownRow(
+            label = "API priority",
+            value = settingsState.apiPriority.storageValue,
+            options = ApiPriority.values().map { it.storageValue },
+        ) { selection ->
+            settingsState = settingsState.copy(apiPriority = ApiPriority.fromStorage(selection))
+        }
+        DropdownRow(
+            label = "Orientation",
+            value = settingsState.orientation.storageValue,
+            options = OrientationOption.values().map { it.storageValue },
+        ) { selection ->
+            settingsState = settingsState.copy(orientation = OrientationOption.fromStorage(selection))
+        }
+        DropdownRow(
+            label = "Video decode",
+            value = settingsState.videoMode.storageValue,
+            options = VideoMode.values().map { it.storageValue },
+        ) { selection ->
+            settingsState = settingsState.copy(videoMode = VideoMode.fromStorage(selection))
+        }
+        NumberRow(
+            label = "Manual width",
+            value = (settingsState.manualWidth ?: 0).takeIf { it > 0 }?.toString() ?: ""
+        ) { value ->
+            val width = value.toIntOrNull()
+            settingsState = settingsState.copy(manualWidth = width)
+        }
+        NumberRow(
+            label = "Manual height",
+            value = (settingsState.manualHeight ?: 0).takeIf { it > 0 }?.toString() ?: ""
+        ) { value ->
+            val height = value.toIntOrNull()
+            settingsState = settingsState.copy(manualHeight = height)
+        }
+        NumberRow(
+            label = "FPS",
+            value = settingsState.fps.toString()
+        ) { value ->
+            val fpsValue = value.toFloatOrNull() ?: settingsState.fps
+            settingsState = settingsState.copy(fps = fpsValue)
+        }
+        Button(onClick = {
+            coroutineScope.launch {
+                withContext(Dispatchers.IO) {
+                    modulePrefs.write(settingsState)
+                    settingsState.sourceUri?.let {
+                        recentDao.insert(
+                            RecentItem(
+                                uri = it.toString(),
+                                type = settingsState.sourceType.storageValue,
+                                addedAt = System.currentTimeMillis()
+                            )
+                        )
+                    }
+                }
+                Toast.makeText(context, "Settings saved", Toast.LENGTH_SHORT).show()
+            }
+        }, enabled = settingsState.sourceUri != null) {
+            Text(text = "Сохранить")
+        }
+        Row(
+            modifier = Modifier.fillMaxWidth(),
+            horizontalArrangement = Arrangement.SpaceBetween
+        ) {
+            TextButton(onClick = onOpenHistory) { Text("История") }
+            TextButton(onClick = onOpenDiagnostics) { Text("Диагностика") }
+            TextButton(onClick = onOpenAbout) { Text("О модуле") }
+        }
+        Text(
+            text = "Video duration: ${TimeUnit.MILLISECONDS.toSeconds(videoDuration)} s",
+            style = MaterialTheme.typography.bodySmall
+        )
+    }
+}
+
+@Composable
+private fun SegmentedToggle(options: List<String>, selectedIndex: Int, onSelectedIndexChange: (Int) -> Unit) {
+    Row(
+        modifier = Modifier.fillMaxWidth(),
+        horizontalArrangement = Arrangement.spacedBy(8.dp)
+    ) {
+        options.forEachIndexed { index, option ->
+            val selected = index == selectedIndex
+            Button(
+                onClick = { onSelectedIndexChange(index) },
+                modifier = Modifier.weight(1f),
+                enabled = !selected
+            ) {
+                Text(text = option)
+            }
+        }
+    }
+}
+
+@Composable
+private fun PreviewCard(
+    settings: ModuleSettings,
+    sliderPosition: Float,
+    onDurationLoaded: (Long) -> Unit,
+    onSliderChanged: (Float) -> Unit
+) {
+    Card(modifier = Modifier.fillMaxWidth()) {
+        Column(modifier = Modifier.padding(16.dp), verticalArrangement = Arrangement.spacedBy(12.dp)) {
+            Text(text = "Предпросмотр", style = MaterialTheme.typography.titleMedium)
+            when (settings.sourceType) {
+                SourceType.IMAGE -> {
+                    AsyncImage(
+                        model = settings.sourceUri,
+                        contentDescription = "Selected image",
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .height(220.dp)
+                    )
+                }
+                SourceType.VIDEO -> {
+                    VideoPreview(
+                        uri = settings.sourceUri,
+                        sliderPosition = sliderPosition,
+                        onDurationLoaded = onDurationLoaded
+                    ) { bitmap ->
+                        if (bitmap != null) {
+                            Image(
+                                bitmap = bitmap.asImageBitmap(),
+                                contentDescription = "Video frame",
+                                modifier = Modifier
+                                    .fillMaxWidth()
+                                    .height(220.dp)
+                            )
+                        } else {
+                            Text("Нет превью")
+                        }
+                    }
+                    Slider(
+                        value = sliderPosition,
+                        onValueChange = onSliderChanged,
+                        modifier = Modifier.fillMaxWidth()
+                    )
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun VideoPreview(
+    uri: Uri?,
+    sliderPosition: Float,
+    onDurationLoaded: (Long) -> Unit,
+    content: @Composable (android.graphics.Bitmap?) -> Unit
+) {
+    var frame by remember(uri) { mutableStateOf<android.graphics.Bitmap?>(null) }
+    val context = LocalContext.current
+    LaunchedEffect(uri, sliderPosition) {
+        frame = null
+        if (uri == null) return@LaunchedEffect
+        val result = withContext(Dispatchers.IO) {
+            val retriever = MediaMetadataRetriever()
+            try {
+                retriever.setDataSource(context, uri)
+                val duration = retriever.extractMetadata(MediaMetadataRetriever.METADATA_KEY_DURATION)?.toLongOrNull() ?: 0L
+                val timeUs = (duration * 1000L * sliderPosition).toLong()
+                val bitmap = retriever.getFrameAtTime(timeUs, MediaMetadataRetriever.OPTION_CLOSEST)
+                Pair(duration, bitmap)
+            } catch (err: Exception) {
+                Pair(0L, null)
+            } finally {
+                try {
+                    retriever.release()
+                } catch (ignored: RuntimeException) {
+                }
+            }
+        }
+        onDurationLoaded(result.first)
+        frame = result.second
+    }
+    content(frame)
+}
+
+@Composable
+private fun SwitchRow(title: String, checked: Boolean, onCheckedChange: (Boolean) -> Unit) {
+    Row(
+        modifier = Modifier.fillMaxWidth(),
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.SpaceBetween
+    ) {
+        Text(text = title)
+        Switch(checked = checked, onCheckedChange = onCheckedChange)
+    }
+}
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+private fun DropdownRow(
+    label: String,
+    value: String,
+    options: List<String>,
+    onSelect: (String) -> Unit
+) {
+    var expanded by remember { mutableStateOf(false) }
+    Column(modifier = Modifier.fillMaxWidth()) {
+        Text(text = label, style = MaterialTheme.typography.labelMedium)
+        Card(onClick = { expanded = !expanded }, modifier = Modifier.fillMaxWidth()) {
+            Row(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(12.dp),
+                horizontalArrangement = Arrangement.SpaceBetween,
+                verticalAlignment = Alignment.CenterVertically
+            ) {
+                Text(value)
+                IconButton(onClick = { expanded = !expanded }) {
+                    Icon(painterResource(id = R.drawable.ic_arrow_drop_down), contentDescription = "Toggle")
+                }
+            }
+        }
+        if (expanded) {
+            Column(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(top = 4.dp),
+                verticalArrangement = Arrangement.spacedBy(4.dp)
+            ) {
+                options.forEach { option ->
+                    TextButton(onClick = {
+                        onSelect(option)
+                        expanded = false
+                    }) {
+                        Text(option)
+                    }
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun NumberRow(
+    label: String,
+    value: String,
+    onValueChanged: (String) -> Unit
+) {
+    var textState by remember(value) { mutableStateOf(value) }
+    Column(modifier = Modifier.fillMaxWidth()) {
+        Text(text = label, style = MaterialTheme.typography.labelMedium)
+        OutlinedTextField(
+            value = textState,
+            onValueChange = {
+                textState = it
+                onValueChanged(it)
+            },
+            modifier = Modifier.fillMaxWidth()
+        )
+    }
+}

--- a/app/src/main/java/com/example/virtualcam/ui/theme/Theme.kt
+++ b/app/src/main/java/com/example/virtualcam/ui/theme/Theme.kt
@@ -1,0 +1,22 @@
+package com.example.virtualcam.ui.theme
+
+import androidx.compose.foundation.isSystemInDarkTheme
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.darkColorScheme
+import androidx.compose.material3.lightColorScheme
+import androidx.compose.runtime.Composable
+
+// GREP: THEME_M3
+private val DarkColors = darkColorScheme()
+private val LightColors = lightColorScheme()
+
+@Composable
+fun VirtualCamTheme(darkTheme: Boolean = isSystemInDarkTheme(), content: @Composable () -> Unit) {
+    val colors = if (darkTheme) DarkColors else LightColors
+    MaterialTheme(
+        colorScheme = colors,
+        typography = MaterialTheme.typography,
+        shapes = MaterialTheme.shapes,
+        content = content
+    )
+}

--- a/app/src/main/java/com/example/virtualcam/util/BitmapConverters.kt
+++ b/app/src/main/java/com/example/virtualcam/util/BitmapConverters.kt
@@ -1,0 +1,151 @@
+package com.example.virtualcam.util
+
+import android.graphics.Bitmap
+import android.graphics.Matrix
+import android.media.Image
+import com.example.virtualcam.logVcam
+import com.example.virtualcam.prefs.ScaleMode
+import java.io.ByteArrayOutputStream
+import java.nio.ByteBuffer
+import kotlin.math.roundToInt
+
+// GREP: BITMAP_TRANSFORM
+fun scaleBitmap(bitmap: Bitmap, targetWidth: Int, targetHeight: Int, scaleMode: ScaleMode): Bitmap {
+    if (bitmap.width == targetWidth && bitmap.height == targetHeight) {
+        return bitmap
+    }
+    val result = when (scaleMode) {
+        ScaleMode.FIT -> {
+            val widthRatio = targetWidth.toFloat() / bitmap.width
+            val heightRatio = targetHeight.toFloat() / bitmap.height
+            val ratio = minOf(widthRatio, heightRatio)
+            val width = (bitmap.width * ratio).roundToInt().coerceAtLeast(1)
+            val height = (bitmap.height * ratio).roundToInt().coerceAtLeast(1)
+            Bitmap.createScaledBitmap(bitmap, width, height, true)
+        }
+        ScaleMode.CENTER_CROP -> {
+            val widthRatio = targetWidth.toFloat() / bitmap.width
+            val heightRatio = targetHeight.toFloat() / bitmap.height
+            val ratio = maxOf(widthRatio, heightRatio)
+            val width = (bitmap.width * ratio).roundToInt().coerceAtLeast(1)
+            val height = (bitmap.height * ratio).roundToInt().coerceAtLeast(1)
+            Bitmap.createScaledBitmap(bitmap, width, height, true)
+        }
+    }
+    if (scaleMode == ScaleMode.CENTER_CROP && (result.width != targetWidth || result.height != targetHeight)) {
+        val xOffset = ((result.width - targetWidth) / 2).coerceAtLeast(0)
+        val yOffset = ((result.height - targetHeight) / 2).coerceAtLeast(0)
+        return Bitmap.createBitmap(result, xOffset, yOffset, targetWidth, targetHeight)
+    }
+    return result
+}
+
+fun applyOrientationAndMirror(bitmap: Bitmap, rotation: Int, mirror: Boolean): Bitmap {
+    val matrix = Matrix()
+    if (rotation != 0) {
+        matrix.postRotate(rotation.toFloat())
+    }
+    if (mirror) {
+        matrix.postScale(-1f, 1f)
+    }
+    return Bitmap.createBitmap(bitmap, 0, 0, bitmap.width, bitmap.height, matrix, true)
+}
+
+// GREP: YUV_CONVERTERS
+// GREP: YUV_CONVERTERS_IMPL
+fun bitmapToNV21(bitmap: Bitmap): ByteArray {
+    val width = bitmap.width
+    val height = bitmap.height
+    val argb = IntArray(width * height)
+    bitmap.getPixels(argb, 0, width, 0, 0, width, height)
+    val yuv = ByteArray(width * height * 3 / 2)
+    var yIndex = 0
+    var uvIndex = width * height
+    for (y in 0 until height) {
+        for (x in 0 until width) {
+            val color = argb[y * width + x]
+            val r = (color shr 16) and 0xFF
+            val g = (color shr 8) and 0xFF
+            val b = color and 0xFF
+            val yValue = ((66 * r + 129 * g + 25 * b + 128) shr 8) + 16
+            val uValue = ((-38 * r - 74 * g + 112 * b + 128) shr 8) + 128
+            val vValue = ((112 * r - 94 * g - 18 * b + 128) shr 8) + 128
+            yuv[yIndex++] = yValue.coerceIn(0, 255).toByte()
+            if (y % 2 == 0 && x % 2 == 0) {
+                yuv[uvIndex++] = vValue.coerceIn(0, 255).toByte()
+                yuv[uvIndex++] = uValue.coerceIn(0, 255).toByte()
+            }
+        }
+    }
+    return yuv
+}
+
+fun writeBitmapIntoYUV420(bitmap: Bitmap, image: Image) {
+    val width = image.width
+    val height = image.height
+    val nv21 = bitmapToNV21(
+        if (bitmap.width == width && bitmap.height == height) bitmap else Bitmap.createScaledBitmap(bitmap, width, height, true)
+    )
+    val planes = image.planes
+    val yPlane = planes[0]
+    val uPlane = planes[1]
+    val vPlane = planes[2]
+
+    yPlane.buffer.position(0)
+    copyPlane(nv21, 0, width, height, yPlane.rowStride, yPlane.pixelStride, yPlane.buffer)
+
+    val uvOffset = width * height
+    val rowStride = uPlane.rowStride
+    val pixelStrideU = uPlane.pixelStride
+    val pixelStrideV = vPlane.pixelStride
+    val uBuffer = uPlane.buffer
+    val vBuffer = vPlane.buffer
+    uBuffer.position(0)
+    vBuffer.position(0)
+    val halfHeight = height / 2
+    val halfWidth = width / 2
+    for (row in 0 until halfHeight) {
+        for (col in 0 until halfWidth) {
+            val vuIndex = uvOffset + row * width + col * 2
+            val vValue = nv21[vuIndex]
+            val uValue = nv21[vuIndex + 1]
+            uBuffer.position(row * rowStride + col * pixelStrideU)
+            uBuffer.put(uValue)
+            vBuffer.position(row * vPlane.rowStride + col * pixelStrideV)
+            vBuffer.put(vValue)
+        }
+    }
+}
+
+private fun copyPlane(
+    source: ByteArray,
+    offset: Int,
+    width: Int,
+    height: Int,
+    rowStride: Int,
+    pixelStride: Int,
+    buffer: ByteBuffer
+) {
+    var index = offset
+    for (row in 0 until height) {
+        val rowPosition = row * rowStride
+        for (col in 0 until width) {
+            val destIndex = rowPosition + col * pixelStride
+            buffer.put(destIndex, source[index])
+            index++
+        }
+    }
+}
+
+fun bitmapToJpeg(bitmap: Bitmap, quality: Int = 90): ByteArray {
+    val stream = ByteArrayOutputStream()
+    return try {
+        bitmap.compress(Bitmap.CompressFormat.JPEG, quality, stream)
+        stream.toByteArray()
+    } catch (err: Exception) {
+        logVcam("bitmapToJpeg error: ${err.message}")
+        ByteArray(0)
+    } finally {
+        stream.close()
+    }
+}

--- a/app/src/main/java/com/example/virtualcam/util/ExifUtil.kt
+++ b/app/src/main/java/com/example/virtualcam/util/ExifUtil.kt
@@ -1,0 +1,47 @@
+package com.example.virtualcam.util
+
+import android.content.ContentResolver
+import android.content.Context
+import android.net.Uri
+import androidx.exifinterface.media.ExifInterface
+import com.example.virtualcam.logVcam
+import java.io.InputStream
+
+// GREP: EXIF_ORIENTATION
+object ExifUtil {
+
+    data class OrientationInfo(val rotationDegrees: Int, val mirrored: Boolean)
+
+    fun readOrientation(context: Context, uri: Uri): OrientationInfo {
+        val resolver: ContentResolver = context.contentResolver
+        var stream: InputStream? = null
+        return try {
+            stream = resolver.openInputStream(uri)
+            if (stream != null) {
+                val exif = ExifInterface(stream)
+                val orientation = exif.getAttributeInt(
+                    ExifInterface.TAG_ORIENTATION,
+                    ExifInterface.ORIENTATION_NORMAL
+                )
+                val (rotation, flip) = when (orientation) {
+                    ExifInterface.ORIENTATION_ROTATE_90 -> 90 to false
+                    ExifInterface.ORIENTATION_ROTATE_180 -> 180 to false
+                    ExifInterface.ORIENTATION_ROTATE_270 -> 270 to false
+                    ExifInterface.ORIENTATION_FLIP_HORIZONTAL -> 0 to true
+                    ExifInterface.ORIENTATION_TRANSPOSE -> 90 to true
+                    ExifInterface.ORIENTATION_TRANSVERSE -> 270 to true
+                    ExifInterface.ORIENTATION_FLIP_VERTICAL -> 180 to true
+                    else -> 0 to false
+                }
+                OrientationInfo(rotation, flip)
+            } else {
+                OrientationInfo(0, false)
+            }
+        } catch (err: Exception) {
+            logVcam("ExifUtil readOrientation error: ${err.message}")
+            OrientationInfo(0, false)
+        } finally {
+            stream?.close()
+        }
+    }
+}

--- a/app/src/main/java/com/example/virtualcam/util/SizeUtil.kt
+++ b/app/src/main/java/com/example/virtualcam/util/SizeUtil.kt
@@ -1,0 +1,100 @@
+package com.example.virtualcam.util
+
+import android.graphics.Color
+import android.graphics.Rect
+import android.graphics.SurfaceTexture
+import android.view.Surface
+import android.util.Size
+import com.example.virtualcam.logVcam
+import kotlin.math.roundToInt
+
+// GREP: SIZE_NEGOTIATION
+object SizeUtil {
+    fun negotiateTargetSize(
+        requestedSize: Size,
+        manualWidth: Int?,
+        manualHeight: Int?
+    ): Size {
+        val width = manualWidth?.takeIf { it > 0 } ?: requestedSize.width
+        val height = manualHeight?.takeIf { it > 0 } ?: requestedSize.height
+        val evenWidth = if (width % 2 == 0) width else width + 1
+        val evenHeight = if (height % 2 == 0) height else height + 1
+        return Size(evenWidth, evenHeight)
+    }
+
+    fun scaleToFit(source: Size, targetWidth: Int, targetHeight: Int): Size {
+        if (source.width == 0 || source.height == 0) return Size(targetWidth, targetHeight)
+        val scale = minOf(
+            targetWidth.toFloat() / source.width,
+            targetHeight.toFloat() / source.height
+        )
+        val width = (source.width * scale).roundToInt().coerceAtLeast(1)
+        val height = (source.height * scale).roundToInt().coerceAtLeast(1)
+        return Size(width, height)
+    }
+}
+
+// GREP: SURFACE_DETECT_IR
+fun isImageReaderSurface(surface: Surface): Boolean {
+    val descriptor = surface.toString()
+    return descriptor.contains("ImageReader") || descriptor.contains("ImageWriter")
+}
+
+// GREP: SURFACE_DETECT_PREVIEW
+fun isPreviewSurface(surface: Surface): Boolean {
+    return surface.isValid && !isImageReaderSurface(surface)
+}
+
+// GREP: DUMMY_SURFACE
+fun makeDummySurface(): Surface {
+    val texture = SurfaceTexture(0)
+    texture.setDefaultBufferSize(16, 16)
+    return Surface(texture)
+}
+
+// GREP: SURFACE_PAINTER
+fun startSurfacePainter(
+    surface: Surface,
+    frameProvider: () -> android.graphics.Bitmap?,
+    fps: Float,
+    clearColor: Int = Color.BLACK
+): Thread {
+    val frameInterval = if (fps > 0f) (1000f / fps).toLong().coerceAtLeast(10L) else 33L
+    val painter = Thread {
+        try {
+            while (!Thread.currentThread().isInterrupted && surface.isValid) {
+                val canvas = try {
+                    surface.lockCanvas(null)
+                } catch (err: Exception) {
+                    logVcam("SurfacePainter lock failed: ${err.message}")
+                    break
+                }
+                try {
+                    canvas.drawColor(clearColor)
+                    val bitmap = frameProvider()
+                    if (bitmap != null && !bitmap.isRecycled) {
+                        val dest = Rect(0, 0, canvas.width, canvas.height)
+                        canvas.drawBitmap(bitmap, null, dest, null)
+                    }
+                } finally {
+                    try {
+                        surface.unlockCanvasAndPost(canvas)
+                    } catch (err: Exception) {
+                        logVcam("SurfacePainter unlock failed: ${err.message}")
+                    }
+                }
+                try {
+                    Thread.sleep(frameInterval)
+                } catch (interrupted: InterruptedException) {
+                    Thread.currentThread().interrupt()
+                }
+            }
+        } catch (err: Exception) {
+            logVcam("SurfacePainter loop error: ${err.message}")
+        }
+    }
+    painter.name = "VirtualCamSurfacePainter"
+    painter.isDaemon = true
+    painter.start()
+    return painter
+}

--- a/app/src/main/java/com/example/virtualcam/xposed/CameraXHooks.kt
+++ b/app/src/main/java/com/example/virtualcam/xposed/CameraXHooks.kt
@@ -1,0 +1,225 @@
+package com.example.virtualcam.xposed
+
+import android.graphics.ImageFormat
+import android.graphics.Matrix
+import android.graphics.Rect
+import android.view.Surface
+import androidx.camera.core.ImageProxy
+import androidx.camera.core.impl.TagBundle
+import com.example.virtualcam.logVcam
+import de.robv.android.xposed.XC_MethodHook
+import de.robv.android.xposed.XposedHelpers
+import java.lang.reflect.Proxy
+import java.nio.ByteBuffer
+import java.util.concurrent.Executor
+import java.util.concurrent.atomic.AtomicBoolean
+
+// GREP: HOOK_CAMERAX
+object CameraXHooks {
+    private val installed = AtomicBoolean(false)
+
+    fun install(classLoader: ClassLoader) {
+        if (installed.getAndSet(true)) return
+        hookImageAnalysis(classLoader)
+        hookImageCapture(classLoader)
+        hookSurfaceRequest(classLoader)
+    }
+
+    private fun hookImageAnalysis(classLoader: ClassLoader) {
+        try {
+            val analysisClass = XposedHelpers.findClass("androidx.camera.core.ImageAnalysis", classLoader)
+            val analyzerInterface = Class.forName("androidx.camera.core.ImageAnalysis$Analyzer", false, classLoader)
+            XposedHelpers.findAndHookMethod(
+                analysisClass,
+                "setAnalyzer",
+                Executor::class.java,
+                analyzerInterface,
+                object : XC_MethodHook() {
+                    override fun beforeHookedMethod(param: MethodHookParam) {
+                        val originalAnalyzer = param.args[1]
+                        val proxy = Proxy.newProxyInstance(
+                            classLoader,
+                            arrayOf(analyzerInterface)
+                        ) { _, method, args ->
+                            if (method.name == "analyze" && args != null && args.isNotEmpty()) {
+                                val imageProxy = args[0] as ImageProxy
+                                FakeFrameInjector.warmUp()
+                                val data = FakeFrameInjector.provideNv21(imageProxy.width, imageProxy.height)
+                                val fake = if (data != null) {
+                                    VirtualCamImageProxy.fromNv21(
+                                        imageProxy.width,
+                                        imageProxy.height,
+                                        imageProxy.imageInfo.timestamp,
+                                        data
+                                    )
+                                } else {
+                                    imageProxy
+                                }
+                                DiagnosticsState.update {
+                                    it.copy(
+                                        activePath = "CameraX",
+                                        previewSize = "${imageProxy.width}x${imageProxy.height}",
+                                        frameFormat = "YUV_420_888"
+                                    )
+                                }
+                                imageProxy.close()
+                                method.invoke(originalAnalyzer, fake)
+                                null
+                            } else {
+                                method.invoke(originalAnalyzer, *(args ?: emptyArray()))
+                            }
+                        }
+                        param.args[1] = proxy
+                    }
+                }
+            )
+        } catch (err: Throwable) {
+            logVcam("CameraX ImageAnalysis hook failed: ${err.message}")
+        }
+    }
+
+    private fun hookImageCapture(classLoader: ClassLoader) {
+        try {
+            val captureClass = XposedHelpers.findClass("androidx.camera.core.ImageCapture", classLoader)
+            val callbackInterface = Class.forName("androidx.camera.core.ImageCapture$OnImageCapturedCallback", false, classLoader)
+            XposedHelpers.findAndHookMethod(
+                captureClass,
+                "takePicture",
+                Executor::class.java,
+                callbackInterface,
+                object : XC_MethodHook() {
+                    override fun beforeHookedMethod(param: MethodHookParam) {
+                        val callback = param.args[1]
+                        val method = callbackInterface.getMethod("onCaptureSuccess", ImageProxy::class.java)
+                        val proxy = Proxy.newProxyInstance(
+                            classLoader,
+                            arrayOf(callbackInterface)
+                        ) { _, methodInvoked, args ->
+                            if (methodInvoked.name == "onCaptureSuccess") {
+                                FakeFrameInjector.warmUp()
+                                val settings = FakeFrameInjector.currentSettings()
+                                val width =  settings?.manualWidth ?: 1280
+                                val height = settings?.manualHeight ?: 720
+                                val data = FakeFrameInjector.provideNv21(width, height)
+                                val fake = if (data != null) {
+                                    VirtualCamImageProxy.fromNv21(width, height, System.currentTimeMillis() * 1000, data)
+                                } else {
+                                    args?.get(0) as? ImageProxy
+                                }
+                                DiagnosticsState.update {
+                                    it.copy(activePath = "CameraX", previewSize = "${width}x${height}")
+                                }
+                                method.invoke(callback, fake)
+                                null
+                            } else if (methodInvoked.name == "onError") {
+                                methodInvoked.invoke(callback, *(args ?: emptyArray()))
+                            } else {
+                                methodInvoked.invoke(callback, *(args ?: emptyArray()))
+                            }
+                        }
+                        param.args[1] = proxy
+                    }
+                }
+            )
+        } catch (err: Throwable) {
+            logVcam("CameraX ImageCapture hook failed: ${err.message}")
+        }
+    }
+
+    private fun hookSurfaceRequest(classLoader: ClassLoader) {
+        try {
+            XposedHelpers.findAndHookMethod(
+                "androidx.camera.core.SurfaceRequest",
+                classLoader,
+                "provideSurface",
+                Surface::class.java,
+                Executor::class.java,
+                Runnable::class.java,
+                object : XC_MethodHook() {
+                    override fun beforeHookedMethod(param: MethodHookParam) {
+                        FakeFrameInjector.warmUp()
+                        val settings = FakeFrameInjector.currentSettings()
+                        if (settings?.injectCam2Preview != true) return
+                        val originalSurface = param.args[0] as Surface
+                        val dummy = com.example.virtualcam.util.makeDummySurface()
+                        com.example.virtualcam.util.startSurfacePainter(originalSurface, {
+                            FakeFrameInjector.acquireBitmap(1280, 720)
+                        }, settings.fps)
+                        DiagnosticsState.update { it.copy(activePath = "CameraX", frameFormat = "Preview", requestedFps = settings.fps) }
+                        param.args[0] = dummy
+                    }
+                }
+            )
+        } catch (err: Throwable) {
+            logVcam("CameraX SurfaceRequest hook failed: ${err.message}")
+        }
+    }
+}
+
+private class VirtualCamImageProxy(
+    private val width: Int,
+    private val height: Int,
+    private val timestampUs: Long,
+    private val planes: Array<ImageProxy.PlaneProxy>
+) : ImageProxy {
+    override fun close() {}
+
+    override fun getWidth(): Int = width
+
+    override fun getHeight(): Int = height
+
+    override fun getImageInfo(): ImageProxy.ImageInfo = object : ImageProxy.ImageInfo {
+        override fun getTimestamp(): Long = timestampUs
+        override fun getTagBundle(): androidx.camera.core.impl.TagBundle = androidx.camera.core.impl.TagBundle.emptyBundle()
+        override fun getSensorToBufferTransformMatrix(): android.graphics.Matrix = android.graphics.Matrix()
+        override fun getRotationDegrees(): Int = 0
+    }
+
+    override fun getPlanes(): Array<ImageProxy.PlaneProxy> = planes
+
+    override fun getFormat(): Int = ImageFormat.YUV_420_888
+
+    override fun getCropRect(): Rect = Rect(0, 0, width, height)
+
+    override fun setCropRect(rect: Rect?) {}
+
+    companion object {
+        fun fromNv21(width: Int, height: Int, timestampUs: Long, data: ByteArray): ImageProxy {
+            val ySize = width * height
+            val uvSize = ySize / 2
+            val yBuffer = ByteBuffer.allocateDirect(ySize)
+            yBuffer.put(data, 0, ySize)
+            val uBuffer = ByteBuffer.allocateDirect(uvSize / 2)
+            val vBuffer = ByteBuffer.allocateDirect(uvSize / 2)
+            var offset = ySize
+            while (offset < data.size) {
+                val v = data[offset]
+                val u = if (offset + 1 < data.size) data[offset + 1] else 0
+                vBuffer.put(v)
+                uBuffer.put(u)
+                offset += 2
+            }
+            yBuffer.flip()
+            uBuffer.flip()
+            vBuffer.flip()
+            val planes = arrayOf(
+                SimplePlaneProxy(yBuffer.asReadOnlyBuffer(), width, 1),
+                SimplePlaneProxy(uBuffer.asReadOnlyBuffer(), width / 2, 1),
+                SimplePlaneProxy(vBuffer.asReadOnlyBuffer(), width / 2, 1)
+            )
+            return VirtualCamImageProxy(width, height, timestampUs, planes)
+        }
+    }
+}
+
+private class SimplePlaneProxy(
+    private val buffer: ByteBuffer,
+    private val rowStride: Int,
+    private val pixelStride: Int
+) : ImageProxy.PlaneProxy {
+    override fun getBuffer(): ByteBuffer = buffer.duplicate()
+
+    override fun getRowStride(): Int = rowStride
+
+    override fun getPixelStride(): Int = pixelStride
+}

--- a/app/src/main/java/com/example/virtualcam/xposed/DiagnosticsState.kt
+++ b/app/src/main/java/com/example/virtualcam/xposed/DiagnosticsState.kt
@@ -1,0 +1,26 @@
+package com.example.virtualcam.xposed
+
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+
+// Helper store for diagnostics shared between hooks and UI
+data class DiagnosticsSnapshot(
+    val activePath: String = "Idle",
+    val previewSize: String = "-",
+    val frameFormat: String = "-",
+    val requestedFps: Float = 0f,
+    val actualFps: Float = 0f
+)
+
+object DiagnosticsState {
+    private val _state = MutableStateFlow(DiagnosticsSnapshot())
+    val state: StateFlow<DiagnosticsSnapshot> = _state
+
+    fun update(transform: (DiagnosticsSnapshot) -> DiagnosticsSnapshot) {
+        _state.value = transform(_state.value)
+    }
+
+    fun set(snapshot: DiagnosticsSnapshot) {
+        _state.value = snapshot
+    }
+}

--- a/app/src/main/java/com/example/virtualcam/xposed/FakeFrameInjector.kt
+++ b/app/src/main/java/com/example/virtualcam/xposed/FakeFrameInjector.kt
@@ -1,0 +1,403 @@
+package com.example.virtualcam.xposed
+
+import android.content.Context
+import android.graphics.Bitmap
+import android.graphics.BitmapFactory
+import android.graphics.ImageFormat
+import android.hardware.Camera
+import android.media.Image
+import android.net.Uri
+import android.os.SystemClock
+import android.util.Size
+import android.view.Surface
+import com.example.virtualcam.logVcam
+import com.example.virtualcam.prefs.ModulePrefs
+import com.example.virtualcam.prefs.ModuleSettings
+import com.example.virtualcam.prefs.OrientationOption
+import com.example.virtualcam.prefs.SourceType
+import com.example.virtualcam.util.ExifUtil
+import com.example.virtualcam.util.SizeUtil
+import com.example.virtualcam.util.applyOrientationAndMirror
+import com.example.virtualcam.util.bitmapToJpeg
+import com.example.virtualcam.util.bitmapToNV21
+import com.example.virtualcam.util.scaleBitmap
+import com.example.virtualcam.util.writeBitmapIntoYUV420
+import de.robv.android.xposed.XC_MethodHook
+import de.robv.android.xposed.XposedHelpers
+import java.io.InputStream
+import java.util.concurrent.ConcurrentHashMap
+import java.util.concurrent.atomic.AtomicBoolean
+
+// GREP: INJECT_PREVIEW_AND_FRAMES
+object FakeFrameInjector {
+    private val legacyCallbacks = ConcurrentHashMap<Camera.PreviewCallback, Camera.PreviewCallback>()
+    private val legacySessions = ConcurrentHashMap<Camera, LegacyCameraSession>()
+    private val painterThreads = ConcurrentHashMap<Surface, Thread>()
+    private val installedLegacy = AtomicBoolean(false)
+    private val installedCamera2 = AtomicBoolean(false)
+
+    private var appContext: Context? = null
+    private var lastSettingsSignature: String? = null
+    private var lastSettings: ModuleSettings? = null
+    private var baseBitmap: Bitmap? = null
+    private var orientedBitmap: Bitmap? = null
+    private var exifRotation: Int = 0
+    private var exifMirror: Boolean = false
+    private var videoDecoder: VideoDecoder? = null
+    private var lastFrameTimestampNs: Long = 0
+
+    fun initialize(context: Context) {
+        if (appContext == null) {
+            appContext = context.applicationContext
+        }
+    }
+
+    fun installHooks(classLoader: ClassLoader) {
+        installLegacyHooks(classLoader)
+        installCamera2Hooks(classLoader)
+        installImageHooks(classLoader)
+    }
+
+    private fun installLegacyHooks(classLoader: ClassLoader) {
+        if (installedLegacy.getAndSet(true)) return
+        try {
+            val cameraClass = XposedHelpers.findClass("android.hardware.Camera", classLoader)
+            XposedHelpers.findAndHookMethod(cameraClass, "setPreviewCallback", Camera.PreviewCallback::class.java,
+                object : XC_MethodHook() {
+                    override fun beforeHookedMethod(param: MethodHookParam) {
+                        val camera = param.thisObject as Camera
+                        val original = param.args[0] as? Camera.PreviewCallback
+                        if (original != null) {
+                            param.args[0] = wrapPreviewCallback(camera, original)
+                        }
+                    }
+                })
+
+            XposedHelpers.findAndHookMethod(cameraClass, "setPreviewCallbackWithBuffer", Camera.PreviewCallback::class.java,
+                object : XC_MethodHook() {
+                    override fun beforeHookedMethod(param: MethodHookParam) {
+                        val camera = param.thisObject as Camera
+                        val original = param.args[0] as? Camera.PreviewCallback
+                        if (original != null) {
+                            param.args[0] = wrapPreviewCallback(camera, original)
+                        }
+                    }
+                })
+
+            XposedHelpers.findAndHookMethod(cameraClass, "setOneShotPreviewCallback", Camera.PreviewCallback::class.java,
+                object : XC_MethodHook() {
+                    override fun beforeHookedMethod(param: MethodHookParam) {
+                        val camera = param.thisObject as Camera
+                        val original = param.args[0] as? Camera.PreviewCallback
+                        if (original != null) {
+                            param.args[0] = wrapPreviewCallback(camera, original)
+                        }
+                    }
+                })
+
+            XposedHelpers.findAndHookMethod(
+                cameraClass,
+                "takePicture",
+                Camera.ShutterCallback::class.java,
+                Camera.PictureCallback::class.java,
+                Camera.PictureCallback::class.java,
+                Camera.PictureCallback::class.java,
+                object : XC_MethodHook() {
+                    override fun beforeHookedMethod(param: MethodHookParam) {
+                        val camera = param.thisObject as Camera
+                        val jpeg = param.args[3] as? Camera.PictureCallback
+                        if (jpeg != null) {
+                            param.args[3] = Camera.PictureCallback { data, cam ->
+                                refreshSettings()
+                                val pictureSize = cam?.parameters?.pictureSize
+                                val width = pictureSize?.width ?: 1280
+                                val height = pictureSize?.height ?: 720
+                                val frame = provideJpeg(width, height)
+                                logVcam("Legacy takePicture override: ${frame?.size ?: 0} bytes")
+                                jpeg.onPictureTaken(frame ?: data, cam)
+                            }
+                        }
+                    }
+                }
+            )
+
+            XposedHelpers.findAndHookMethod(cameraClass, "release", object : XC_MethodHook() {
+                override fun afterHookedMethod(param: MethodHookParam) {
+                    val camera = param.thisObject as Camera
+                    legacySessions.remove(camera)
+                }
+            })
+        } catch (err: Throwable) {
+            logVcam("Legacy hook install failed: ${err.message}")
+        }
+    }
+
+    private fun installCamera2Hooks(classLoader: ClassLoader) {
+        if (installedCamera2.getAndSet(true)) return
+        try {
+            val stateCallbackClass = Class.forName("android.hardware.camera2.CameraCaptureSession$StateCallback", false, classLoader)
+            val cameraDeviceClass = XposedHelpers.findClass("android.hardware.camera2.CameraDevice", classLoader)
+            XposedHelpers.findAndHookMethod(
+                cameraDeviceClass,
+                "createCaptureSession",
+                MutableList::class.java,
+                stateCallbackClass,
+                Handler::class.java,
+                object : XC_MethodHook() {
+                    override fun beforeHookedMethod(param: MethodHookParam) {
+                        refreshSettings()
+                        val settings = lastSettings ?: return
+                        if (!settings.injectCam2Preview) return
+                        val surfaces = param.args[0] as MutableList<Surface>
+                        var replaced = 0
+                        for (i in surfaces.indices) {
+                            val surface = surfaces[i]
+                            if (isSurfaceEligible(surface)) {
+                                surfaces[i] = com.example.virtualcam.util.makeDummySurface()
+                                startPainter(surface)
+                                replaced++
+                            }
+                        }
+                        if (replaced > 0) {
+                            logVcam("createCaptureSession: replaced $replaced preview surface(s) with dummy")
+                            DiagnosticsState.update { it.copy(activePath = "Camera2") }
+                        }
+                    }
+                }
+            )
+        } catch (err: Throwable) {
+            logVcam("Camera2 hook install failed: ${err.message}")
+        }
+    }
+
+    private fun installImageHooks(classLoader: ClassLoader) {
+        try {
+            val imageReaderClass = XposedHelpers.findClass("android.media.ImageReader", classLoader)
+            XposedHelpers.findAndHookMethod(imageReaderClass, "acquireNextImage", object : XC_MethodHook() {
+                override fun afterHookedMethod(param: MethodHookParam) {
+                    val image = param.result as? Image ?: return
+                    refreshSettings()
+                    provideImage(image)
+                }
+            })
+            XposedHelpers.findAndHookMethod(imageReaderClass, "acquireLatestImage", object : XC_MethodHook() {
+                override fun afterHookedMethod(param: MethodHookParam) {
+                    val image = param.result as? Image ?: return
+                    refreshSettings()
+                    provideImage(image)
+                }
+            })
+        } catch (err: Throwable) {
+            logVcam("ImageReader hook install failed: ${err.message}")
+        }
+    }
+
+    private fun isSurfaceEligible(surface: Surface): Boolean {
+        return com.example.virtualcam.util.isPreviewSurface(surface) && !com.example.virtualcam.util.isImageReaderSurface(surface)
+    }
+
+    private fun startPainter(targetSurface: Surface) {
+        painterThreads[targetSurface]?.interrupt()
+        val fps = lastSettings?.fps ?: 30f
+        val thread = GlSurfacePusher.start(targetSurface, {
+            fetchBitmap(1280, 720)
+        }, fps)
+        painterThreads[targetSurface] = thread
+    }
+
+    private fun wrapPreviewCallback(camera: Camera, original: Camera.PreviewCallback): Camera.PreviewCallback {
+        val cached = legacyCallbacks[original]
+        if (cached != null) {
+            return cached
+        }
+        val wrapper = Camera.PreviewCallback { data, cam ->
+            refreshSettings()
+            val parameters = cam?.parameters
+            val previewSize = parameters?.previewSize
+            if (previewSize != null) {
+                val frame = provideNv21(previewSize.width, previewSize.height)
+                if (frame != null) {
+                    if (data != null && data.size == frame.size) {
+                        System.arraycopy(frame, 0, data, 0, frame.size)
+                        original.onPreviewFrame(data, cam)
+                    } else {
+                        original.onPreviewFrame(frame, cam)
+                    }
+                    recordLegacySession(cam ?: camera, previewSize.width, previewSize.height)
+                } else {
+                    original.onPreviewFrame(data, cam)
+                }
+            } else {
+                original.onPreviewFrame(data, cam)
+            }
+        }
+        legacyCallbacks[original] = wrapper
+        return wrapper
+    }
+
+    private fun recordLegacySession(camera: Camera, width: Int, height: Int) {
+        legacySessions.getOrPut(camera) { LegacyCameraSession() }.previewSize = Size(width, height)
+        DiagnosticsState.update {
+            it.copy(
+                activePath = "Legacy",
+                previewSize = "${width}x${height}",
+                frameFormat = lastSettings?.format?.storageValue ?: "NV21",
+                requestedFps = lastSettings?.fps ?: 30f,
+                actualFps = computeActualFps()
+            )
+        }
+    }
+
+    private fun computeActualFps(): Float {
+        val now = SystemClock.elapsedRealtimeNanos()
+        val previous = lastFrameTimestampNs
+        lastFrameTimestampNs = now
+        return if (previous == 0L) 0f else 1_000_000_000f / (now - previous)
+    }
+
+    private fun refreshSettings() {
+        val context = appContext ?: return
+        val prefs = ModulePrefs.getInstance(context)
+        val settings = prefs.read()
+        val signature = buildString {
+            append(settings.sourceType.storageValue)
+            append('|')
+            append(settings.sourceUri?.toString() ?: "")
+            append('|')
+            append(settings.scaleMode.storageValue)
+            append('|')
+            append(settings.orientation.storageValue)
+            append('|')
+            append(settings.mirror)
+            append('|')
+            append(settings.videoMode.storageValue)
+        }
+        if (signature != lastSettingsSignature) {
+            configure(context, settings)
+            lastSettingsSignature = signature
+        }
+        lastSettings = settings
+    }
+
+    private fun configure(context: Context, settings: ModuleSettings) {
+        releaseResources()
+        when (settings.sourceType) {
+            SourceType.IMAGE -> settings.sourceUri?.let { loadBitmap(context, it, settings) }
+            SourceType.VIDEO -> {
+                val uri = settings.sourceUri ?: return
+                videoDecoder = VideoDecoder(context, uri, settings.videoMode, settings.fps).also { it.start() }
+            }
+        }
+        DiagnosticsState.update {
+            it.copy(
+                activePath = if (settings.sourceType == SourceType.IMAGE) "Static" else "Video",
+                frameFormat = settings.format.storageValue,
+                requestedFps = settings.fps
+            )
+        }
+    }
+
+    private fun loadBitmap(context: Context, uri: Uri, settings: ModuleSettings) {
+        var stream: InputStream? = null
+        try {
+            stream = context.contentResolver.openInputStream(uri)
+            val original = BitmapFactory.decodeStream(stream) ?: return
+            val orientation = if (settings.orientation == OrientationOption.AUTO) {
+                ExifUtil.readOrientation(context, uri)
+            } else {
+                ExifUtil.OrientationInfo(settings.orientation.degrees ?: 0, false)
+            }
+            exifRotation = orientation.rotationDegrees
+            exifMirror = orientation.mirrored
+            val oriented = applyOrientationAndMirror(original, exifRotation, settings.mirror xor exifMirror)
+            baseBitmap = original
+            orientedBitmap = oriented
+        } catch (err: Exception) {
+            logVcam("loadBitmap error: ${err.message}")
+        } finally {
+            stream?.close()
+        }
+    }
+
+    private fun fetchBitmap(targetWidth: Int, targetHeight: Int): Bitmap? {
+        val settings = lastSettings ?: return null
+        val base = when (settings.sourceType) {
+            SourceType.IMAGE -> orientedBitmap
+            SourceType.VIDEO -> videoDecoder?.nextBitmap()?.let { frame ->
+                val rotation = if (settings.orientation == OrientationOption.AUTO) 0 else settings.orientation.degrees ?: 0
+                val transformed = applyOrientationAndMirror(frame, rotation, settings.mirror)
+                if (transformed != frame) {
+                    frame.recycle()
+                }
+                transformed
+            }
+        } ?: return null
+        val negotiated = SizeUtil.negotiateTargetSize(Size(targetWidth, targetHeight), settings.manualWidth, settings.manualHeight)
+        val scaled = scaleBitmap(base, negotiated.width, negotiated.height, settings.scaleMode)
+        return if (scaled == base) scaled else scaled.copy(Bitmap.Config.ARGB_8888, false)
+    }
+
+    fun provideNv21(width: Int, height: Int): ByteArray? {
+        val bitmap = fetchBitmap(width, height) ?: return null
+        val data = bitmapToNV21(bitmap)
+        DiagnosticsState.update {
+            it.copy(previewSize = "${width}x${height}", actualFps = computeActualFps())
+        }
+        return data
+    }
+
+    fun provideJpeg(width: Int, height: Int): ByteArray? {
+        val bitmap = fetchBitmap(width, height) ?: return null
+        return bitmapToJpeg(bitmap)
+    }
+
+    fun provideImage(image: Image) {
+        val bitmap = fetchBitmap(image.width, image.height) ?: return
+        when (image.format) {
+            android.graphics.ImageFormat.YUV_420_888 -> writeBitmapIntoYUV420(bitmap, image)
+            android.graphics.ImageFormat.JPEG -> {
+                val buffer = image.planes[0].buffer
+                buffer.position(0)
+                buffer.put(bitmapToJpeg(bitmap))
+            }
+            android.graphics.ImageFormat.NV21 -> {
+                val buffer = image.planes[0].buffer
+                buffer.position(0)
+                buffer.put(bitmapToNV21(bitmap))
+            }
+        }
+        DiagnosticsState.update {
+            it.copy(
+                previewSize = "${image.width}x${image.height}",
+                frameFormat = when (image.format) {
+                    android.graphics.ImageFormat.YUV_420_888 -> "YUV_420_888"
+                    android.graphics.ImageFormat.JPEG -> "JPEG"
+                    android.graphics.ImageFormat.NV21 -> "NV21"
+                    else -> image.format.toString()
+                },
+                actualFps = computeActualFps()
+            )
+        }
+    }
+
+    private fun releaseResources() {
+        orientedBitmap?.recycle()
+        orientedBitmap = null
+        baseBitmap?.recycle()
+        baseBitmap = null
+        videoDecoder?.release()
+        videoDecoder = null
+    }
+
+    private class LegacyCameraSession {
+        var previewSize: Size = Size(0, 0)
+    }
+
+    fun warmUp() {
+        refreshSettings()
+    }
+
+    fun currentSettings(): ModuleSettings? = lastSettings
+
+    fun acquireBitmap(width: Int, height: Int): Bitmap? = fetchBitmap(width, height)
+}

--- a/app/src/main/java/com/example/virtualcam/xposed/GlSurfacePusher.kt
+++ b/app/src/main/java/com/example/virtualcam/xposed/GlSurfacePusher.kt
@@ -1,0 +1,14 @@
+package com.example.virtualcam.xposed
+
+import android.graphics.Bitmap
+import android.view.Surface
+import com.example.virtualcam.logVcam
+import com.example.virtualcam.util.startSurfacePainter
+
+// GREP: PREVIEW_CANVAS_OR_EGL
+object GlSurfacePusher {
+    fun start(surface: Surface, frameProvider: () -> Bitmap?, fps: Float): Thread {
+        logVcam("GlSurfacePusher using Canvas fallback")
+        return startSurfacePainter(surface, frameProvider, fps)
+    }
+}

--- a/app/src/main/java/com/example/virtualcam/xposed/HookEntry.kt
+++ b/app/src/main/java/com/example/virtualcam/xposed/HookEntry.kt
@@ -1,0 +1,50 @@
+package com.example.virtualcam.xposed
+
+import android.app.Application
+import com.example.virtualcam.logVcam
+import com.example.virtualcam.prefs.ModulePrefs
+import de.robv.android.xposed.IXposedHookLoadPackage
+import de.robv.android.xposed.XC_MethodHook
+import de.robv.android.xposed.XposedHelpers
+import de.robv.android.xposed.callbacks.XC_LoadPackage
+
+// GREP: HOOK_ENTRY
+class HookEntry : IXposedHookLoadPackage {
+
+    private val initializedPackages = mutableSetOf<String>()
+
+    override fun handleLoadPackage(lpparam: XC_LoadPackage.LoadPackageParam) {
+        if (lpparam.packageName == "com.example.virtualcam") return
+        if (!initializedPackages.add(lpparam.packageName)) return
+        try {
+            XposedHelpers.findAndHookMethod(
+                "android.app.Application",
+                lpparam.classLoader,
+                "onCreate",
+                object : XC_MethodHook() {
+                    override fun afterHookedMethod(param: MethodHookParam) {
+                        val app = param.thisObject as Application
+                        install(app, lpparam.classLoader)
+                    }
+                }
+            )
+        } catch (err: Throwable) {
+            logVcam("HookEntry: application hook failed ${err.message}")
+        }
+    }
+
+    private fun install(app: Application, classLoader: ClassLoader) {
+        val context = app.applicationContext
+        val prefs = ModulePrefs.getInstance(context)
+        val settings = prefs.read()
+        if (!settings.enabled) {
+            logVcam("VirtualCam disabled for ${context.packageName}")
+            return
+        }
+        FakeFrameInjector.initialize(context)
+        FakeFrameInjector.installHooks(classLoader)
+        FakeFrameInjector.warmUp()
+        CameraXHooks.install(classLoader)
+        logVcam("VirtualCam initialized in ${context.packageName}")
+    }
+}

--- a/app/src/main/java/com/example/virtualcam/xposed/VideoDecoder.kt
+++ b/app/src/main/java/com/example/virtualcam/xposed/VideoDecoder.kt
@@ -1,0 +1,231 @@
+package com.example.virtualcam.xposed
+
+import android.content.Context
+import android.graphics.Bitmap
+import android.graphics.BitmapFactory
+import android.graphics.ImageFormat
+import android.graphics.Rect
+import android.media.Image
+import android.media.MediaCodec
+import android.media.MediaCodecInfo
+import android.media.MediaCodecList
+import android.media.MediaExtractor
+import android.media.MediaFormat
+import android.media.MediaMetadataRetriever
+import android.net.Uri
+import com.example.virtualcam.logVcam
+import com.example.virtualcam.prefs.VideoMode
+import java.io.ByteArrayOutputStream
+import java.util.concurrent.atomic.AtomicBoolean
+
+// GREP: DECODER_CODEC_OR_MMR
+class VideoDecoder(
+    private val context: Context,
+    private val uri: Uri,
+    private val mode: VideoMode,
+    private val targetFps: Float
+) {
+    private val started = AtomicBoolean(false)
+    private var retriever: MediaMetadataRetriever? = null
+    private var extractor: MediaExtractor? = null
+    private var codec: MediaCodec? = null
+    private var bufferInfo: MediaCodec.BufferInfo? = null
+    private var durationUs: Long = 0
+    private var stepUs: Long = 33_000L
+    private var positionUs: Long = 0
+    private var sawInputEos = false
+    private var sawOutputEos = false
+
+    fun start() {
+        if (!started.compareAndSet(false, true)) return
+        when (mode) {
+            VideoMode.MMR -> setupRetriever()
+            VideoMode.CODEC -> if (!setupCodec()) setupRetriever()
+        }
+    }
+
+    fun nextBitmap(): Bitmap? {
+        return when {
+            codec != null -> codecFrame()
+            retriever != null -> mmrFrame()
+            else -> null
+        }
+    }
+
+    fun release() {
+        retriever?.release()
+        retriever = null
+        try {
+            codec?.stop()
+        } catch (_: Exception) {
+        }
+        codec?.release()
+        codec = null
+        extractor?.release()
+        extractor = null
+        bufferInfo = null
+        started.set(false)
+    }
+
+    private fun setupRetriever() {
+        val retriever = MediaMetadataRetriever()
+        retriever.setDataSource(context, uri)
+        durationUs = (retriever.extractMetadata(MediaMetadataRetriever.METADATA_KEY_DURATION)?.toLongOrNull() ?: 0L) * 1000L
+        stepUs = computeStepUs()
+        positionUs = 0
+        this.retriever = retriever
+        logVcam("VideoDecoder using MediaMetadataRetriever durationUs=$durationUs stepUs=$stepUs")
+    }
+
+    private fun setupCodec(): Boolean {
+        return try {
+            val extractor = MediaExtractor()
+            extractor.setDataSource(context, uri, null)
+            var trackIndex = -1
+            var format: MediaFormat? = null
+            for (i in 0 until extractor.trackCount) {
+                val candidate = extractor.getTrackFormat(i)
+                val mime = candidate.getString(MediaFormat.KEY_MIME)
+                if (mime?.startsWith("video/") == true) {
+                    trackIndex = i
+                    format = candidate
+                    break
+                }
+            }
+            if (trackIndex < 0 || format == null) {
+                extractor.release()
+                return false
+            }
+            extractor.selectTrack(trackIndex)
+            if (!format.containsKey(MediaFormat.KEY_COLOR_FORMAT)) {
+                format.setInteger(MediaFormat.KEY_COLOR_FORMAT, MediaCodecInfo.CodecCapabilities.COLOR_FormatYUV420Flexible)
+            }
+            val codecName = MediaCodecList(MediaCodecList.ALL_CODECS).findDecoderForFormat(format)
+            val codec = if (codecName != null) MediaCodec.createByCodecName(codecName) else MediaCodec.createDecoderByType(format.getString(MediaFormat.KEY_MIME)!!)
+            codec.configure(format, null, null, 0)
+            codec.start()
+            this.codec = codec
+            this.extractor = extractor
+            bufferInfo = MediaCodec.BufferInfo()
+            durationUs = if (format.containsKey(MediaFormat.KEY_DURATION)) format.getLong(MediaFormat.KEY_DURATION) else 0L
+            if (durationUs == 0L) {
+                val tmp = MediaMetadataRetriever()
+                tmp.setDataSource(context, uri)
+                durationUs = (tmp.extractMetadata(MediaMetadataRetriever.METADATA_KEY_DURATION)?.toLongOrNull() ?: 0L) * 1000L
+                tmp.release()
+            }
+            stepUs = computeStepUs()
+            positionUs = 0
+            logVcam("VideoDecoder using MediaCodec durationUs=$durationUs stepUs=$stepUs")
+            true
+        } catch (err: Exception) {
+            logVcam("VideoDecoder setupCodec error: ${err.message}")
+            false
+        }
+    }
+
+    private fun computeStepUs(): Long {
+        return if (targetFps > 0f) (1_000_000f / targetFps).toLong().coerceAtLeast(15_000L) else 33_000L
+    }
+
+    private fun mmrFrame(): Bitmap? {
+        val retriever = retriever ?: return null
+        val bitmap = retriever.getFrameAtTime(positionUs, MediaMetadataRetriever.OPTION_CLOSEST)
+        positionUs += stepUs
+        if (durationUs > 0 && positionUs > durationUs) {
+            positionUs = 0
+        }
+        return bitmap
+    }
+
+    private fun codecFrame(): Bitmap? {
+        val codec = codec ?: return mmrFrame()
+        val extractor = extractor ?: return mmrFrame()
+        val info = bufferInfo ?: return mmrFrame()
+        var attempts = 0
+        var bitmap: Bitmap? = null
+        while (attempts < 8 && bitmap == null) {
+            if (!sawInputEos) {
+                val inputIndex = codec.dequeueInputBuffer(10_000)
+                if (inputIndex >= 0) {
+                    val buffer = codec.getInputBuffer(inputIndex) ?: continue
+                    val size = extractor.readSampleData(buffer, 0)
+                    if (size < 0) {
+                        codec.queueInputBuffer(inputIndex, 0, 0, 0, MediaCodec.BUFFER_FLAG_END_OF_STREAM)
+                        sawInputEos = true
+                    } else {
+                        val presentationTimeUs = extractor.sampleTime
+                        codec.queueInputBuffer(inputIndex, 0, size, presentationTimeUs, 0)
+                        extractor.advance()
+                    }
+                }
+            }
+            val outputIndex = codec.dequeueOutputBuffer(info, 10_000)
+            if (outputIndex >= 0) {
+                if (info.flags and MediaCodec.BUFFER_FLAG_END_OF_STREAM != 0) {
+                    sawOutputEos = true
+                }
+                val image = codec.getOutputImage(outputIndex)
+                if (image != null) {
+                    bitmap = imageToBitmap(image)
+                    image.close()
+                }
+                codec.releaseOutputBuffer(outputIndex, false)
+            } else if (outputIndex == MediaCodec.INFO_OUTPUT_FORMAT_CHANGED) {
+                logVcam("VideoDecoder output format: ${codec.outputFormat}")
+            }
+            if (sawOutputEos) {
+                extractor.seekTo(0, MediaExtractor.SEEK_TO_CLOSEST_SYNC)
+                codec.flush()
+                sawInputEos = false
+                sawOutputEos = false
+            }
+            attempts++
+        }
+        if (bitmap == null) {
+            bitmap = mmrFrame()
+        }
+        return bitmap
+    }
+
+    private fun imageToBitmap(image: Image): Bitmap {
+        val nv21 = yuv420ToNv21(image)
+        val yuvImage = android.graphics.YuvImage(nv21, ImageFormat.NV21, image.width, image.height, null)
+        val output = ByteArrayOutputStream()
+        yuvImage.compressToJpeg(Rect(0, 0, image.width, image.height), 90, output)
+        val bytes = output.toByteArray()
+        output.close()
+        return BitmapFactory.decodeByteArray(bytes, 0, bytes.size)
+    }
+
+    private fun yuv420ToNv21(image: Image): ByteArray {
+        val width = image.width
+        val height = image.height
+        val ySize = width * height
+        val nv21 = ByteArray(ySize * 3 / 2)
+        val yPlane = image.planes[0]
+        val uPlane = image.planes[1]
+        val vPlane = image.planes[2]
+        var outputPos = 0
+        for (row in 0 until height) {
+            var col = 0
+            while (col < width) {
+                val yIndex = row * yPlane.rowStride + col * yPlane.pixelStride
+                nv21[outputPos++] = yPlane.buffer.get(yIndex)
+                col++
+            }
+        }
+        var uvPos = ySize
+        for (row in 0 until height / 2) {
+            var col = 0
+            while (col < width / 2) {
+                val uIndex = row * uPlane.rowStride + col * uPlane.pixelStride
+                val vIndex = row * vPlane.rowStride + col * vPlane.pixelStride
+                nv21[uvPos++] = vPlane.buffer.get(vIndex)
+                nv21[uvPos++] = uPlane.buffer.get(uIndex)
+                col++
+            }
+        }
+        return nv21
+    }
+}

--- a/app/src/main/res/drawable/ic_arrow_drop_down.xml
+++ b/app/src/main/res/drawable/ic_arrow_drop_down.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <path
+        android:fillColor="#FFFFFFFF"
+        android:pathData="M7,10l5,5 5,-5z" />
+</vector>

--- a/app/src/main/res/drawable/ic_launcher_foreground.xml
+++ b/app/src/main/res/drawable/ic_launcher_foreground.xml
@@ -1,0 +1,15 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="108dp"
+    android:height="108dp"
+    android:viewportWidth="108"
+    android:viewportHeight="108">
+    <path
+        android:fillColor="#FFFFFF"
+        android:pathData="M18,18h72v72h-72z" />
+    <path
+        android:fillColor="#6750A4"
+        android:pathData="M34,34h40v40h-40z" />
+    <path
+        android:fillColor="#FFFFFF"
+        android:pathData="M42,42l16,12l-16,12z" />
+</vector>

--- a/app/src/main/res/mipmap-anydpi-v26/ic_launcher.xml
+++ b/app/src/main/res/mipmap-anydpi-v26/ic_launcher.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<adaptive-icon xmlns:android="http://schemas.android.com/apk/res/android">
+    <background android:drawable="@color/ic_launcher_background" />
+    <foreground android:drawable="@drawable/ic_launcher_foreground" />
+</adaptive-icon>

--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <color name="seed">#6750A4</color>
+</resources>

--- a/app/src/main/res/values/ic_launcher_background.xml
+++ b/app/src/main/res/values/ic_launcher_background.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <color name="ic_launcher_background">#121212</color>
+</resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="app_name">VirtualCam</string>
+</resources>

--- a/app/src/main/res/values/themes.xml
+++ b/app/src/main/res/values/themes.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <style name="Theme.VirtualCam" parent="Theme.Material3.DayNight.NoActionBar">
+        <item name="android:statusBarColor">?attr/colorPrimary</item>
+    </style>
+</resources>

--- a/app/src/main/res/xml/data_extraction_rules.xml
+++ b/app/src/main/res/xml/data_extraction_rules.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+<data-extraction-rules xmlns:android="http://schemas.android.com/apk/res/android">
+    <cloud-backup>
+        <include domain="sharedpref" />
+        <include domain="database" />
+    </cloud-backup>
+    <device-transfer>
+        <include domain="sharedpref" />
+        <include domain="database" />
+    </device-transfer>
+</data-extraction-rules>

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,0 +1,6 @@
+plugins {
+    id("com.android.application") version "8.5.2" apply false
+    id("org.jetbrains.kotlin.android") version "1.9.24" apply false
+    id("org.jetbrains.kotlin.kapt") version "1.9.24" apply false
+    id("org.jlleitschuh.gradle.ktlint") version "12.1.1" apply false
+}

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,0 +1,4 @@
+org.gradle.jvmargs=-Xmx4g -Dfile.encoding=UTF-8
+android.useAndroidX=true
+android.enableJetifier=true
+kotlin.code.style=official

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,0 +1,5 @@
+distributionBase=GRADLE_USER_HOME
+distributionPath=wrapper/dists
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.7-bin.zip
+zipStoreBase=GRADLE_USER_HOME
+zipStorePath=wrapper/dists

--- a/gradlew
+++ b/gradlew
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+set -euo pipefail
+REQUIRED_VERSION_MAJOR=8
+REQUIRED_VERSION_MINOR=7
+if ! command -v gradle >/dev/null 2>&1; then
+  echo "Gradle executable not found. Please install Gradle ${REQUIRED_VERSION_MAJOR}.${REQUIRED_VERSION_MINOR} or newer." >&2
+  exit 1
+fi
+VERSION_LINE=$(gradle -v | head -n 1)
+if [[ ! "$VERSION_LINE" =~ Gradle ]]; then
+  VERSION_LINE=$(gradle -v | grep Gradle || true)
+fi
+VERSION=$(echo "$VERSION_LINE" | awk '{print $2}')
+IFS='.' read -r major minor patch <<<"$VERSION"
+if [[ $major -lt $REQUIRED_VERSION_MAJOR || ($major -eq $REQUIRED_VERSION_MAJOR && ${minor:-0} -lt $REQUIRED_VERSION_MINOR) ]]; then
+  echo "Gradle $VERSION is too old. Need >= ${REQUIRED_VERSION_MAJOR}.${REQUIRED_VERSION_MINOR}" >&2
+  exit 1
+fi
+exec gradle "$@"

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -1,0 +1,18 @@
+pluginManagement {
+    repositories {
+        gradlePluginPortal()
+        google()
+        mavenCentral()
+    }
+}
+
+dependencyResolutionManagement {
+    repositoriesMode.set(RepositoriesMode.FAIL_ON_PROJECT_REPOS)
+    repositories {
+        google()
+        mavenCentral()
+    }
+}
+
+rootProject.name = "VirtualCam"
+include(":app")


### PR DESCRIPTION
## Summary
- scaffold a Compose Material 3 Android app module for the VirtualCam LSPosed project and register the Xposed entry point
- implement device-protected world-readable preferences, Room history, SAF proxy provider, and Compose UI flows with media preview
- add bitmap conversion utilities, video decoding helpers, diagnostics state, and hook implementations for legacy Camera, Camera2, and CameraX APIs

## Testing
- `./gradlew --console=plain clean assembleDebug lint ktlintCheck` *(fails: plugin com.android.application 8.5.2 unavailable in offline environment)*

------
https://chatgpt.com/codex/tasks/task_b_68d038c73810832bb7da8881bce9e396