### PR TITLE
Configure Room verifier to use writable SQLite temp dir

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -1,4 +1,5 @@
 // GREP: GRADLE_APP
+import org.jetbrains.kotlin.gradle.internal.KaptWithoutKotlincTask
 plugins {
     id("com.android.application")
     id("org.jetbrains.kotlin.android")
@@ -115,4 +116,13 @@ dependencies {
     androidTestImplementation("androidx.test.espresso:espresso-core:3.5.1")
     androidTestImplementation(platform("androidx.compose:compose-bom:2024.06.00"))
     androidTestImplementation("androidx.compose.ui:ui-test-junit4")
+}
+
+val sqliteTmpDir = layout.buildDirectory.dir("tmp/sqlite-jdbc")
+
+tasks.withType<KaptWithoutKotlincTask>().configureEach {
+    kaptProcessJvmArgs.add("-Dorg.sqlite.tmpdir=${sqliteTmpDir.get().asFile.absolutePath}")
+    doFirst {
+        sqliteTmpDir.get().asFile.mkdirs()
+    }
 }


### PR DESCRIPTION
## Summary
- ensure kapt-based Room verification passes a writable temp directory to the bundled SQLite JDBC loader
- create the directory before the kapt task runs so the SQLite library can extract itself safely

## Testing
- `./gradlew :app:kaptDebugKotlin --console=plain` *(fails in the execution environment because the Android Gradle Plugin cannot be downloaded)*

------
https://chatgpt.com/codex/tasks/task_b_68d047174ff0832bb5ecfb58ec61d489