### PR TITLE
Fix Android build errors from Compose UI and CameraX hooks

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -1,4 +1,5 @@
 // GREP: GRADLE_APP
+import org.jetbrains.kotlin.gradle.internal.KaptWithoutKotlincTask
 plugins {
     id("com.android.application")
     id("org.jetbrains.kotlin.android")
@@ -48,7 +49,7 @@ android {
     }
 
     composeOptions {
-        kotlinCompilerExtensionVersion = "1.5.11"
+        kotlinCompilerExtensionVersion = "1.5.14"
     }
 
     packaging {
@@ -115,4 +116,13 @@ dependencies {
     androidTestImplementation("androidx.test.espresso:espresso-core:3.5.1")
     androidTestImplementation(platform("androidx.compose:compose-bom:2024.06.00"))
     androidTestImplementation("androidx.compose.ui:ui-test-junit4")
+}
+
+val sqliteTmpDir = layout.buildDirectory.dir("tmp/sqlite-jdbc")
+
+tasks.withType<KaptWithoutKotlincTask>().configureEach {
+    kaptProcessJvmArgs.add("-Dorg.sqlite.tmpdir=${sqliteTmpDir.get().asFile.absolutePath}")
+    doFirst {
+        sqliteTmpDir.get().asFile.mkdirs()
+    }
 }

--- a/app/src/main/java/com/example/virtualcam/ui/AboutActivity.kt
+++ b/app/src/main/java/com/example/virtualcam/ui/AboutActivity.kt
@@ -3,6 +3,7 @@ package com.example.virtualcam.ui
 import android.content.Intent
 import android.net.Uri
 import android.os.Bundle
+import android.os.Build
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
 import androidx.compose.foundation.layout.Arrangement
@@ -14,13 +15,10 @@ import androidx.compose.material3.Button
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
-import androidx.compose.ui.text.AnnotatedString
-import androidx.compose.ui.text.buildAnnotatedString
-import androidx.compose.ui.text.style.TextDecoration
 import androidx.compose.ui.unit.dp
-import com.example.virtualcam.BuildConfig
 import com.example.virtualcam.ui.theme.VirtualCamTheme
 
 // GREP: UI_ABOUT
@@ -39,6 +37,21 @@ class AboutActivity : ComponentActivity() {
 private fun AboutScreen() {
     val context = LocalContext.current
     val repoLink = "https://github.com/example/virtualcam"
+    val versionName = remember {
+        val packageManager = context.packageManager
+        val packageName = context.packageName
+        runCatching {
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+                packageManager.getPackageInfo(
+                    packageName,
+                    android.content.pm.PackageManager.PackageInfoFlags.of(0)
+                ).versionName
+            } else {
+                @Suppress("DEPRECATION")
+                packageManager.getPackageInfo(packageName, 0).versionName
+            }
+        }.getOrNull() ?: "-"
+    }
     Column(
         modifier = Modifier
             .fillMaxSize()
@@ -46,7 +59,7 @@ private fun AboutScreen() {
         verticalArrangement = Arrangement.spacedBy(12.dp)
     ) {
         Text(text = "VirtualCam", style = MaterialTheme.typography.headlineMedium)
-        Text(text = "Version: ${BuildConfig.VERSION_NAME}")
+        Text(text = "Version: $versionName")
         Text(text = "License: Apache-2.0")
         Text(
             text = "Репозиторий:",

--- a/app/src/main/java/com/example/virtualcam/ui/MainActivity.kt
+++ b/app/src/main/java/com/example/virtualcam/ui/MainActivity.kt
@@ -7,6 +7,7 @@ import android.os.Bundle
 import android.widget.Toast
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.rememberLauncherForActivityResult
+import androidx.activity.compose.setContent
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.layout.Arrangement

--- a/app/src/main/java/com/example/virtualcam/xposed/CameraXHooks.kt
+++ b/app/src/main/java/com/example/virtualcam/xposed/CameraXHooks.kt
@@ -3,6 +3,7 @@ package com.example.virtualcam.xposed
 import android.graphics.ImageFormat
 import android.graphics.Matrix
 import android.graphics.Rect
+import android.media.Image
 import android.view.Surface
 import androidx.camera.core.ImageProxy
 import androidx.camera.core.impl.TagBundle
@@ -28,7 +29,7 @@ object CameraXHooks {
     private fun hookImageAnalysis(classLoader: ClassLoader) {
         try {
             val analysisClass = XposedHelpers.findClass("androidx.camera.core.ImageAnalysis", classLoader)
-            val analyzerInterface = Class.forName("androidx.camera.core.ImageAnalysis$Analyzer", false, classLoader)
+            val analyzerInterface = Class.forName("androidx.camera.core.ImageAnalysis\$Analyzer", false, classLoader)
             XposedHelpers.findAndHookMethod(
                 analysisClass,
                 "setAnalyzer",
@@ -81,7 +82,7 @@ object CameraXHooks {
     private fun hookImageCapture(classLoader: ClassLoader) {
         try {
             val captureClass = XposedHelpers.findClass("androidx.camera.core.ImageCapture", classLoader)
-            val callbackInterface = Class.forName("androidx.camera.core.ImageCapture$OnImageCapturedCallback", false, classLoader)
+            val callbackInterface = Class.forName("androidx.camera.core.ImageCapture\$OnImageCapturedCallback", false, classLoader)
             XposedHelpers.findAndHookMethod(
                 captureClass,
                 "takePicture",
@@ -168,10 +169,12 @@ private class VirtualCamImageProxy(
 
     override fun getHeight(): Int = height
 
+    override fun getImage(): Image? = null
+
     override fun getImageInfo(): ImageProxy.ImageInfo = object : ImageProxy.ImageInfo {
         override fun getTimestamp(): Long = timestampUs
-        override fun getTagBundle(): androidx.camera.core.impl.TagBundle = androidx.camera.core.impl.TagBundle.emptyBundle()
-        override fun getSensorToBufferTransformMatrix(): android.graphics.Matrix = android.graphics.Matrix()
+        override fun getTagBundle(): TagBundle = TagBundle.emptyBundle()
+        override fun getSensorToBufferTransformMatrix(): Matrix = Matrix()
         override fun getRotationDegrees(): Int = 0
     }
 
@@ -202,7 +205,7 @@ private class VirtualCamImageProxy(
             yBuffer.flip()
             uBuffer.flip()
             vBuffer.flip()
-            val planes = arrayOf(
+            val planes = arrayOf<ImageProxy.PlaneProxy>(
                 SimplePlaneProxy(yBuffer.asReadOnlyBuffer(), width, 1),
                 SimplePlaneProxy(uBuffer.asReadOnlyBuffer(), width / 2, 1),
                 SimplePlaneProxy(vBuffer.asReadOnlyBuffer(), width / 2, 1)

--- a/app/src/main/java/com/example/virtualcam/xposed/FakeFrameInjector.kt
+++ b/app/src/main/java/com/example/virtualcam/xposed/FakeFrameInjector.kt
@@ -7,6 +7,7 @@ import android.graphics.ImageFormat
 import android.hardware.Camera
 import android.media.Image
 import android.net.Uri
+import android.os.Handler
 import android.os.SystemClock
 import android.util.Size
 import android.view.Surface
@@ -135,7 +136,7 @@ object FakeFrameInjector {
     private fun installCamera2Hooks(classLoader: ClassLoader) {
         if (installedCamera2.getAndSet(true)) return
         try {
-            val stateCallbackClass = Class.forName("android.hardware.camera2.CameraCaptureSession$StateCallback", false, classLoader)
+            val stateCallbackClass = Class.forName("android.hardware.camera2.CameraCaptureSession\$StateCallback", false, classLoader)
             val cameraDeviceClass = XposedHelpers.findClass("android.hardware.camera2.CameraDevice", classLoader)
             XposedHelpers.findAndHookMethod(
                 cameraDeviceClass,


### PR DESCRIPTION
## Summary
- resolve the About screen's version display through PackageManager so it no longer depends on a generated BuildConfig constant
- import ComponentActivity.setContent in MainActivity so the Compose compiler recognizes the activity content lambda
- escape CameraX nested class names and flesh out the ImageProxy shim so the hook stubs compile against camera-core
- add the missing Handler import and escape the Camera2 StateCallback reference used by the fake frame injector

## Testing
- `./gradlew :app:compileDebugKotlin --stacktrace` *(fails in this environment because the required JDK toolchain cannot be downloaded)*

------
https://chatgpt.com/codex/tasks/task_b_68d047174ff0832bb5ecfb58ec61d489