### PR TITLE
Sync legacy preview texture buffer size

### DIFF
--- a/app/src/main/java/com/example/virtualcam/xposed/FakeFrameInjector.kt
+++ b/app/src/main/java/com/example/virtualcam/xposed/FakeFrameInjector.kt
@@ -399,7 +399,12 @@ object FakeFrameInjector {
     }
 
     private fun recordLegacySession(camera: Camera, width: Int, height: Int) {
-        legacySessions.getOrPut(camera) { LegacyCameraSession() }.previewSize = Size(width, height)
+        val session = legacySessions.getOrPut(camera) { LegacyCameraSession() }
+        session.previewSize = Size(width, height)
+        val texture = session.attachedSurfaceTexture
+        if (texture != null && texture !== session.dummySurfaceTexture) {
+            runCatching { texture.setDefaultBufferSize(width, height) }
+        }
         DiagnosticsState.update {
             it.copy(
                 activePath = "Legacy",


### PR DESCRIPTION
## Summary
- update legacy session tracking to retain the session instance when recording preview dimensions
- sync the real preview SurfaceTexture buffer size with the negotiated camera preview size while avoiding the dummy texture

## Testing
- ./gradlew test *(fails: SDK location not found in container)*

------
https://chatgpt.com/codex/tasks/task_b_68d065d68410832ba189c051cdf21651