### PR TITLE
Add resolver fallback for inaccessible media sources

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -40,9 +40,7 @@
             android:authorities="com.example.virtualcam.provider"
             android:enabled="true"
             android:exported="true"
-            android:grantUriPermissions="true"
-            android:readPermission="android.permission.READ_EXTERNAL_STORAGE"
-            android:writePermission="android.permission.READ_EXTERNAL_STORAGE" />
+            android:grantUriPermissions="true" />
 
         <meta-data
             android:name="xposedmodule"

--- a/app/src/main/java/com/example/virtualcam/provider/VirtualCamProvider.kt
+++ b/app/src/main/java/com/example/virtualcam/provider/VirtualCamProvider.kt
@@ -45,7 +45,7 @@ class VirtualCamProvider : ContentProvider() {
         val context = context ?: throw FileNotFoundException("No context")
         val settings = ModulePrefs.getInstance(context).read()
         val sourceUri = settings.sourceUri ?: throw FileNotFoundException("Source not configured")
-        if (uri.path != "/selected") {
+        if (uri.path != SELECTED_PATH) {
             throw FileNotFoundException("Unsupported path: ${uri.path}")
         }
         val callingPkg = callingPackage
@@ -58,5 +58,11 @@ class VirtualCamProvider : ContentProvider() {
             }
         }
         return context.contentResolver.openFileDescriptor(sourceUri, mode)
+    }
+
+    companion object {
+        const val AUTHORITY: String = "com.example.virtualcam.provider"
+        private const val SELECTED_PATH: String = "/selected"
+        val SELECTED_URI: Uri = Uri.parse("content://$AUTHORITY$SELECTED_PATH")
     }
 }

--- a/app/src/main/java/com/example/virtualcam/util/SourceUriResolver.kt
+++ b/app/src/main/java/com/example/virtualcam/util/SourceUriResolver.kt
@@ -1,0 +1,44 @@
+package com.example.virtualcam.util
+
+import android.content.Context
+import android.net.Uri
+import com.example.virtualcam.logVcam
+import com.example.virtualcam.provider.VirtualCamProvider
+import java.io.FileNotFoundException
+import kotlin.io.use
+
+object SourceUriResolver {
+    fun resolve(context: Context, preferred: Uri?): Uri? {
+        if (preferred == null) {
+            return null
+        }
+        if (canRead(context, preferred)) {
+            return preferred
+        }
+        val proxy = VirtualCamProvider.SELECTED_URI
+        if (preferred != proxy && canRead(context, proxy)) {
+            logVcam("SourceUriResolver: falling back to provider URI for $preferred")
+            return proxy
+        }
+        logVcam("SourceUriResolver: unable to access $preferred")
+        return null
+    }
+
+    private fun canRead(context: Context, uri: Uri): Boolean {
+        return try {
+            val fd = context.contentResolver.openFileDescriptor(uri, "r")
+            if (fd != null) {
+                fd.use { }
+                true
+            } else {
+                false
+            }
+        } catch (err: SecurityException) {
+            false
+        } catch (err: FileNotFoundException) {
+            false
+        } catch (err: Exception) {
+            false
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add a SourceUriResolver utility that falls back to the module provider when the original SAF URI is not readable
- update FakeFrameInjector to resolve image/video sources through the new helper before loading media
- expose provider URI constants and relax manifest permissions so hooked apps can consume the proxy content provider

## Testing
- `./gradlew lint` *(fails: Android SDK not available in container)*

------
https://chatgpt.com/codex/tasks/task_b_68d0698509d8832ba0911fd41dc93701