### PR TITLE
Fix module preferences context resolution

### DIFF
--- a/app/src/main/java/com/example/virtualcam/prefs/ModulePrefs.kt
+++ b/app/src/main/java/com/example/virtualcam/prefs/ModulePrefs.kt
@@ -5,6 +5,7 @@ import android.content.SharedPreferences
 import android.net.Uri
 import android.os.Build
 import androidx.core.content.edit
+import com.example.virtualcam.BuildConfig
 import com.example.virtualcam.logVcam
 import java.io.File
 
@@ -106,16 +107,21 @@ data class ModuleSettings(
 class ModulePrefs private constructor(context: Context) {
 
     // GREP: PREFS_DPS_WORLD_READABLE
-    private val dpsContext: Context = context.createDeviceProtectedStorageContext()
+    private val baseContext: Context = context
+    private val dpsContext: Context = baseContext.createDeviceProtectedStorageContext()
     private val prefs: SharedPreferences
 
     init {
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) {
-            dpsContext.moveSharedPreferencesFrom(context, PrefKeys.PREF_FILE)
+            dpsContext.moveSharedPreferencesFrom(baseContext, PrefKeys.PREF_FILE)
         }
-        @Suppress("DEPRECATION")
-        val mode = Context.MODE_WORLD_READABLE
-        prefs = dpsContext.getSharedPreferences(PrefKeys.PREF_FILE, mode)
+        prefs = try {
+            @Suppress("DEPRECATION")
+            dpsContext.getSharedPreferences(PrefKeys.PREF_FILE, Context.MODE_WORLD_READABLE)
+        } catch (err: SecurityException) {
+            logVcam("ModulePrefs: MODE_WORLD_READABLE unsupported (${err.message}), falling back to MODE_PRIVATE")
+            dpsContext.getSharedPreferences(PrefKeys.PREF_FILE, Context.MODE_PRIVATE)
+        }
         ensureWorldReadable()
     }
 
@@ -174,8 +180,26 @@ class ModulePrefs private constructor(context: Context) {
         private var instance: ModulePrefs? = null
 
         fun getInstance(context: Context): ModulePrefs {
+            val moduleContext = resolveModuleContext(context)
             return instance ?: synchronized(this) {
-                instance ?: ModulePrefs(context.applicationContext).also { instance = it }
+                instance ?: ModulePrefs(moduleContext).also { instance = it }
+            }
+        }
+
+        private fun resolveModuleContext(context: Context): Context {
+            val appContext = context.applicationContext ?: context
+            if (appContext.packageName == BuildConfig.APPLICATION_ID) {
+                return appContext
+            }
+            return try {
+                val pkgContext = appContext.createPackageContext(
+                    BuildConfig.APPLICATION_ID,
+                    Context.CONTEXT_IGNORE_SECURITY
+                )
+                pkgContext.applicationContext ?: pkgContext
+            } catch (err: Exception) {
+                logVcam("ModulePrefs: createPackageContext failed (${err.message}); using caller context")
+                appContext
             }
         }
     }


### PR DESCRIPTION
## Summary
- ensure the hooked process reads module preferences using the module context
- fall back to MODE_PRIVATE if MODE_WORLD_READABLE is rejected while keeping the file world readable

## Testing
- `./gradlew ktlintCheck` *(fails: dependency downloads blocked with HTTP 403)*

------
https://chatgpt.com/codex/tasks/task_b_68d06ddce744832b9d93f0948010e2a5